### PR TITLE
Proxy objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(
   include/wxUI/Choice.h
   include/wxUI/ComboBox.h
   include/wxUI/Custom.h
+  include/wxUI/GetterSetter.h
   include/wxUI/Hyperlink.h
   include/wxUI/Layout.h
   include/wxUI/Line.h

--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@ C++ header-only library to make declarative UIs for wxWidgets.
 ## Quick Start
 
 ```cpp
+#include <numeric>
 #include <wx/wx.h>
 #include <wxUI/wxUI.h>
 
 class ExampleDialog : public wxDialog {
 public:
     explicit ExampleDialog(wxWindow* parent);
+    wxUI::SpinCtrl::Proxy a, b;
+    wxUI::Text::Proxy result;
 };
 
 ExampleDialog::ExampleDialog(wxWindow* parent)
@@ -18,6 +21,7 @@ ExampleDialog::ExampleDialog(wxWindow* parent)
         wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     using namespace wxUI;
+
     VSizer {
         wxSizerFlags().Expand().Border(),
         VSizer {
@@ -31,6 +35,20 @@ ExampleDialog::ExampleDialog(wxWindow* parent)
                 "what the UI looks like." }
                 .withStyle(wxTE_MULTILINE)
                 .withSize(wxSize(200, 100))
+        },
+        HSizer {
+            Text { "A =" },
+            a = SpinCtrl { std::pair { 1, 10000 } }
+                    .bind([this]() {
+                        *result = std::to_string(std::gcd(static_cast<int>(*a), static_cast<int>(*b)));
+                    }),
+
+            Text { "B =" },
+            b = SpinCtrl { std::pair { 1, 10000 } }
+                    .bind([this]() { *result = std::to_string(std::gcd(static_cast<int>(*a), static_cast<int>(*b))); }),
+
+            Text { "GCD = " },
+            result = Text { "1" },
         },
         RadioBox { "&Log Levels:", { "&Information", "&Warning", "&Error", "&None", "&Custom" } }
             .withStyle(wxRA_SPECIFY_ROWS)
@@ -55,7 +73,7 @@ ExampleDialog::ExampleDialog(wxWindow* parent)
 
         Generic { CreateStdDialogButtonSizer(wxOK) },
     }
-        .attachTo(this);
+        .attachToAndFit(this);
 }
 ```
 <img src="docs/images/ExampleDialog.png"/>
@@ -103,6 +121,7 @@ ExampleDialog::ExampleDialog(wxWindow* parent)
         wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     using namespace wxUI;
+
     VSizer {
         wxSizerFlags().Expand().Border(),
         VSizer {
@@ -112,9 +131,23 @@ ExampleDialog::ExampleDialog(wxWindow* parent)
                 .withStyle(wxALIGN_LEFT),
     // ...
         },
+        HSizer {
+            Text { "A =" },
+            a = SpinCtrl { std::pair { 1, 10000 } }
+                    .bind([this]() {
+                        *result = std::to_string(std::gcd(static_cast<int>(*a), static_cast<int>(*b)));
+                    }),
+
+            Text { "B =" },
+            b = SpinCtrl { std::pair { 1, 10000 } }
+                    .bind([this]() { *result = std::to_string(std::gcd(static_cast<int>(*a), static_cast<int>(*b))); }),
+
+            Text { "GCD = " },
+            result = Text { "1" },
+        },
     // ...
     }
-        .attachTo(this);
+        .attachToAndFit(this);
 }
 ```
 

--- a/docs/ProgrammersGuide.md
+++ b/docs/ProgrammersGuide.md
@@ -5,7 +5,7 @@ C++ header-only library to make declarative UIs for wxWidgets.
 
 This overview provides an overview of `wxUI`, but is not intented to be a tutorial on `wxWidgets`.  We assume the reader has working knowledge of `wxWidgets`.  Great documentation and guides are available at [https://www.wxwidgets.org](https://www.wxwidgets.org).
 
-In `wxUI`, you use "Menu" to declary the layout of your menu items and the "actions" they call.  Similarly, you use "Sizers" to declare the layout of "Controllers" for your application.
+In `wxUI`, you use `wxUI::Menu` to declare the layout of your menu items and the "actions" they call.  Similarly, you use `wxUI::Sizer` to declare the layout of *Controllers* for your application.
 
 ### Menu
 
@@ -35,17 +35,21 @@ HelloWorldFrame::HelloWorldFrame()
 
 In `wxWidgets` the general paradigm is to create an enumeration of identity ints that you associate with a member, then you would bind, either statically or dynamically, to a function.  With `wxUI::Menu` the construction of the identify and assocation with a function is handled automatically.  By default `wxUI::Menu` starts the enumeration with `wxID_AUTO_LOWEST` and increments for each item.  Take caution if you use these enumerations as it may collide with other ids assocated with the frame.
 
-The top level `MenuBar` holds a collection of `Menu` objects.  The `Menu` object consists of a name of the menu, and a collection of "Items", which can be one of `Item` (normal), `Separator`, `CheckItem`, and `RadioItem`.
+The top level `wxUI::MenuBar` holds a collection of `wxUI::Menu` objects.  The `wxUI::Menu` object consists of a name of the menu, and a collection of "Items", which can be one of `wxUI::Item` (normal), `wxUI::Separator`, `wxUI::CheckItem`, and `wxUI::RadioItem`.
 
 Menu Items are generally a name with a handler lambda, or name and id with a lambda.  Menu Items can also be assocated with `wxStandardID`.  Many of these like `wxID_EXIT` and `wxID_HELP` have predefined name, help, and handlers, so declaration with just an ID is allowed.
 
 Handlers are callable items that handle events.  The handler can be declared with both no arguments or the `wxCommandEvent` argument for deeper inspection of the event.
 
 ```cpp
-            wxUI::Item { "&Example1...\tCtrl-D", [] {
+            wxUI::Separator {}, wxUI::Item { "&ExtendedExample...", [this] {
+                                                ExtendedExample dialog(this);
+                                                dialog.ShowModal();
+                                            } },
+            wxUI::Item { "&Example Item...", [] {
                             wxLogMessage("Hello World!");
                         } },
-            wxUI::CheckItem { "&Example2...\tCtrl-D", [](wxCommandEvent& event) {
+            wxUI::CheckItem { "&Example Checked Item...", [](wxCommandEvent& event) {
                                  wxLogMessage(event.IsChecked() ? "is checked" : "is not checked");
                              } },
 ```
@@ -63,7 +67,7 @@ Items { "Name", Handler }
 Items { "Name", "Help", Handler }
 ```
 
-wxUI::Menu also allows nesting of menus.  This allows complicated menus to be composed easily.
+`wxUI::Menu` also allows nesting of menus.  This allows complicated menus to be composed easily.
 
 ```cpp
         wxUI::Menu {
@@ -77,6 +81,16 @@ wxUI::Menu also allows nesting of menus.  This allows complicated menus to be co
                                            } },
                       },
     // ...
+            wxUI::Separator {}, wxUI::Item { "&ExtendedExample...", [this] {
+                                                ExtendedExample dialog(this);
+                                                dialog.ShowModal();
+                                            } },
+            wxUI::Item { "&Example Item...", [] {
+                            wxLogMessage("Hello World!");
+                        } },
+            wxUI::CheckItem { "&Example Checked Item...", [](wxCommandEvent& event) {
+                                 wxLogMessage(event.IsChecked() ? "is checked" : "is not checked");
+                             } },
         },
 ```
 
@@ -85,7 +99,7 @@ The `wxUI::MenuBar` and related objects are generally "lazy" objects.  They hold
 
 ### Layout
 
-The basics of `wxUI` layout is the "Layout".  You use a specific type of "Layout", with the `VSizer` (Vertical Sizer or "row") and `HSizer` (Horizontal Sizer or "column") being the most common. When a "Layout" is set as the top level, it uses the layout as a sort of "blueprint" for stamping out the UI by constructing the ownership hierarchy and layout.
+The basics of `wxUI` layout is the *Layout*.  You use a specific type of *Layout*, with the `wxUI::VSizer` (Vertical Sizer or "row") and `wxUI::HSizer` (Horizontal Sizer or "column") being the most common. When a *Layout* is set as the top level, it uses the layout as a sort of "blueprint" for stamping out the UI by constructing the ownership hierarchy and layout.
 
 ```cpp
     VSizer {
@@ -94,12 +108,12 @@ The basics of `wxUI` layout is the "Layout".  You use a specific type of "Layout
             "Text examples",
     // ...
     }
-        .attachTo(this);
+        .attachToAndFit(this);
 ```
 
 In the above example we have constructed a vertical layout sizer that will use a `wxSizer` with the `wxSizerFlags` set to expand with a default border.  Then the first item in the sizer is a second layer sizer with horizontal layout.  The `wxSizerFlags` are propogated to each layer so the horizontal layout in this example would also be set to expand with a default border.  The second sizer would be created as a "named" box horizonal sizer.
 
-A "Layout" takes a collection of Items, which can be either additional "Layout" (to create a tree of "Layouts") or "Controllers".  Here is the general form of constructions for Sizers:
+A *Layout* takes a collection of objects, which can be either additional *Layout* (to create a tree of *Layouts*) or *Controllers*.  Here is the general form of constructions for *Sizers*:
 
 ```
 Sizer { Items... }
@@ -108,9 +122,9 @@ Sizer { "Name", Items... }
 Sizer { "Name", SizerFlags, Items... }
 ```
 
-`wxUI` supports 3 flavors of Sizers: `VSizer` (Vertical Sizers), `HSizer` (Horizontal Sizers), and `FlexGridSizer` (Flexible Grid Sizers).  Both `VSizer` and `HSizer` can be created with a string to create a "named" box.
+`wxUI` supports 3 flavors of Sizers: `wxUI::VSizer` (Vertical Sizers), `wxUI::HSizer` (Horizontal Sizers), and `wxUI::FlexGridSizer` (Flexible Grid Sizers).  Both `wxUI::VSizer` and `wxUI::HSizer` can be created with a string to create a "named" box.
 
-Note: Because Sizers are intented to be "recursive" data structures, it is possible for a `VSizer` to contain a `VSizer`.  However, be aware that if an empty `VSizer` is created with *just* a `VSizer` as the argument, we collapse that to be a single `VSizer`.  ie, this:
+Note: Because Sizers are intented to be "recursive" data structures, it is possible for a `wxUI::VSizer` to contain a `wxUI::VSizer`.  However, be aware that if an empty `wxUI::VSizer` is created with *just* a `wxUI::VSizer` as the argument, we collapse that to be a single `wxUI::VSizer`.  ie, this:
 
 ```
 wxUI::VSizer { wxUI::VSizer { "Current Frame" } }.attachTo(this);
@@ -125,7 +139,7 @@ wxUI::VSizer { "Current Frame" }.attachTo(this);
 
 #### Generic
 
-One special type of "Layout" is `Generic`.  There are cases where you may have an existing layout as a `wxSizer` (such as a common dialog) or `wxWindow` (such as a custom window) that you wish to use with `wxUI`.  This is a case to use `Generic`:
+One special type of *Layout* is `Generic`.  There are cases where you may have an existing layout as a `wxSizer` (such as a common dialog) or `wxWindow` (such as a custom window) that you wish to use with `wxUI`.  This is a case to use `Generic`:
 
 ```cpp
     VSizer {
@@ -133,12 +147,12 @@ One special type of "Layout" is `Generic`.  There are cases where you may have a
     // ...
         Generic { CreateStdDialogButtonSizer(wxOK) },
     }
-        .attachTo(this);
+        .attachToAndFit(this);
 ```
 
 ### Controllers
 
-"Controllers" are the general term to refer to items that behave like a [`wxContol`](https://docs.wxwidgets.org/3.0/classwx_control.html).  In `wxUI` we attempt to conform a consistent style that favors the common things you do with a specific `wxControl`.
+*Controllers* are the general term to refer to items that behave like a [`wxContol`](https://docs.wxwidgets.org/3.0/classwx_control.html).  In `wxUI` we attempt to conform a consistent style that favors the common things you do with a specific `wxControl`.
 
 ```cpp
         HSizer {
@@ -150,7 +164,7 @@ One special type of "Layout" is `Generic`.  There are cases where you may have a
         },
 ```
 
-By default "Controllers" are constructed using the default arguments for position, style, size, etc.  "Controllers" are designed to use Method Chaining to specialize the way the controller is constructed.  In the example above we see that `TextCtrl` is being augmented with the style `wxALIGN_LEFT`.
+By default *Controllers* are constructed using the default arguments for position, style, size, etc.  *Controllers* are designed to use [Method Chaining](https://en.wikipedia.org/wiki/Method_chaining) to specialize the way the controller is constructed.  In the example above we see that `wxUI::TextCtrl` is being augmented with the style `wxALIGN_LEFT`.
 
 The list of Methods supported by all controllers:
 
@@ -158,30 +172,9 @@ The list of Methods supported by all controllers:
  * `withSize(wxSize size)` : Specifies the `size` of the `wxControl`.
  * `withStyle(long style)` : Specifies the `style` of the `wxControl`.
 
-The "Controllers" currently supported by `wxUI`:
-
- * `Bitmap` for `wxStaticBitmap`
- * `BitmapButton` for `wxBitmapButton`
- * `BitmapComboBox` for `wxBitmapComboBox`
- * `BitmapToggleButton` for `wxBitmapToggleButton`
- * `Button` for `wxButton`
- * `CheckBox` for `wxCheckBox`
- * `Choice` for `wxChoice`
- * `ComboBox` for `wxComboBox`
- * `Hypertext` for `wxHypertextCtrl`
- * `ListBox` for `wxListBox`
- * `Line` for `wxStaticLine`
- * `RadioBox` for `wxRadioBox`
- * `Slider` for `wxSlider`
- * `SpinCtrl` for `wxSpinCtrl`
- * `Text` for `wxStaticText`
- * `TextCtrl` for `wxTextCtrl`
-
-Additional "Contollers" should be easy to add in future updates.
-
 #### Bind
 
-Some "Controllers" support "Binding" a function call to their event handlers.  When the event for that controller is emitted, the function-like object supplied will be called.
+Some *Controllers* support "binding" a function call to their event handlers.  When the event for that controller is emitted, the function-like object supplied will be called.
 
 ```cpp
             Button { wxSizerFlags().Border(wxRIGHT), "Left" }
@@ -192,9 +185,16 @@ Some "Controllers" support "Binding" a function call to their event handlers.  W
 
 For convenience the event parameter of the function can be omitted in cases where it is unused.
 
-#### `getHandle`
+#### Proxy
 
-Often a `wxWindow` object needs to be referenced.  For example, perhaps for reading a currently selected value.  "Controllers" support `getHandle`, a way to get the handle to the underlying `wxWindow` that is created for the "Controller".  You provide the address of the handle that you would like to be populated when the "Controller" is created
+Often the value of a *Controller* in a layout needs to be referenced, or sometimes the backing `wxWindow` itself needs to be used directly.  This could be for reading a currently typed in value in a `TextCtrl`, or to change the selection of a `Choice`.  *Controllers* support `Proxy` objects, a way to get the handle to the underlying `wxWindow` that is created for the *Controller*.
+
+Some *Controllers* do not support values that are intended to change, such as a `Line`, and others can have several values of interest, such as a `ComboBox`.  `Proxy` objects can have several accessors that allow access to these, most commonly called `value()` and `selection()` (see Supported Controllers for details of each supported *Controller*).  These accessors are proxy objects support `get()` and `set()` functions, as well as a set of appropriate overloads for the underlying type, allowing more ergonomic interaction with the code.  `Proxy` also supplies `operator*` and `operator->` which reference the most common accessor.
+
+`Proxy` supply `control()`, which is intended to allow access to the underlying controller.
+
+As `Proxy` objects need to be a named variable that exist outside of a *Controller*, and require being "attached".  This is done with the `operator=`, allowing for an ergonomic way to attach `Proxy` objects to controls.  Accessing a proxy object that has not been attached to a controller will cause an exception to be raised.
+
 
 ```cpp
 auto getHandle(UnderlyingType** handlePtr);
@@ -213,15 +213,36 @@ ExtendedExample::ExtendedExample(wxWindow* parent)
 {
     using namespace wxUI;
     VSizer {
-        TextCtrl { "Hello" }
-            .getHandle(&mText),
-        },
+        proxy = TextCtrl { "Hello" }
     }
         .attachTo(this);
 }
 ```
 
-Note that this handle is non-owning, so it is vital to not have the ptr participate in any lifecycle management of the object.
+#### Supported Controllers
+
+The "Controllers" currently supported by `wxUI`:
+
+| wxUI                 | wxWidget               | Proxy                     | Proxy accessors value |
+| :------------------- | :--------------------- | :------------------------ | :-------------- |
+| `Bitmap`             | `wxStaticBitmap`       | `BitmapProxy`             | n/a             |
+| `BitmapButton`       | `wxBitmapButton`       | `BitmapButtonProxy`       | n/a             |
+| `BitmapComboBox`     | `wxBitmapComboBox`     | `BitmapComboBoxProxy`     | `selection` -> `int`<BR>`value` -> `std::string`<BR>*default*: `value` |
+| `BitmapToggleButton` | `wxBitmapToggleButton` | `BitmapToggleButtonProxy` | `value` -> `bool`<BR>*default*: `value` |
+| `Button`             | `wxButton`             | `ButtonProxy`             | n/a             |
+| `CheckBox`           | `wxCheckBox`           | `CheckBoxProxy`           | `value` -> `bool`<BR>*default*: `value` |
+| `Choice`             | `wxChoice`             | `ChoiceProxy`             | `selection` -> `int`<BR>*default*: `selection` |
+| `ComboBox`           | `wxComboBox`           | `ComboBoxProxy`           | `selection` -> `int`<BR>`value` -> `std::string`<BR>*default*: `value` |
+| `Hypertext`          | `wxHypertextCtrl`      | `HypertextProxy`          | n/a             |
+| `Line`               | `wxStaticLine`         | `LineProxy`               | n/a             |
+| `ListBox`            | `wxListBox`            | `ListBoxProxy`            | `selection` -> `int`<BR>*default*: `selection` |
+| `RadioBox`           | `wxRadioBox`           | `RadioBoxProxy`           | `selection` -> `int`<BR>*default*: `selection` |
+| `Slider`             | `wxSlider`             | `SliderProxy`             | `value` -> `int`<BR>*default*: `value` |
+| `SpinCtrl`           | `wxSpinCtrl`           | `SpinCtrlProxy`           | `value` -> `int`<BR>*default*: `value` |
+| `Text`               | `wxStaticText`         | `TextProxy`               | `label` -> `std::string`<BR>*default*: `label` |
+| `TextCtrl`           | `wxTextCtrl`           | `TextCtrlProxy`           | `label` -> `std::string`<BR>*default*: `label` |
+
+Additional "Contollers" should be easy to add in future updates.
 
 #### Custom
 
@@ -247,6 +268,7 @@ You would then create the controller to confomr
                 },
             },
         },
+        Generic { CreateStdDialogButtonSizer(wxOK) },
 ```
 
 #### Misc notes.

--- a/docs/src/docs/ProgrammersGuide.md
+++ b/docs/src/docs/ProgrammersGuide.md
@@ -5,7 +5,7 @@ C++ header-only library to make declarative UIs for wxWidgets.
 
 This overview provides an overview of `wxUI`, but is not intented to be a tutorial on `wxWidgets`.  We assume the reader has working knowledge of `wxWidgets`.  Great documentation and guides are available at [https://www.wxwidgets.org](https://www.wxwidgets.org).
 
-In `wxUI`, you use "Menu" to declary the layout of your menu items and the "actions" they call.  Similarly, you use "Sizers" to declare the layout of "Controllers" for your application.
+In `wxUI`, you use `wxUI::Menu` to declare the layout of your menu items and the "actions" they call.  Similarly, you use `wxUI::Sizer` to declare the layout of *Controllers* for your application.
 
 ### Menu
 
@@ -19,7 +19,7 @@ The general concept is you declare a set of structures and then `attachTo` a fra
 
 In `wxWidgets` the general paradigm is to create an enumeration of identity ints that you associate with a member, then you would bind, either statically or dynamically, to a function.  With `wxUI::Menu` the construction of the identify and assocation with a function is handled automatically.  By default `wxUI::Menu` starts the enumeration with `wxID_AUTO_LOWEST` and increments for each item.  Take caution if you use these enumerations as it may collide with other ids assocated with the frame.
 
-The top level `MenuBar` holds a collection of `Menu` objects.  The `Menu` object consists of a name of the menu, and a collection of "Items", which can be one of `Item` (normal), `Separator`, `CheckItem`, and `RadioItem`.
+The top level `wxUI::MenuBar` holds a collection of `wxUI::Menu` objects.  The `wxUI::Menu` object consists of a name of the menu, and a collection of "Items", which can be one of `wxUI::Item` (normal), `wxUI::Separator`, `wxUI::CheckItem`, and `wxUI::RadioItem`.
 
 Menu Items are generally a name with a handler lambda, or name and id with a lambda.  Menu Items can also be assocated with `wxStandardID`.  Many of these like `wxID_EXIT` and `wxID_HELP` have predefined name, help, and handlers, so declaration with just an ID is allowed.
 
@@ -42,7 +42,7 @@ Items { "Name", Handler }
 Items { "Name", "Help", Handler }
 ```
 
-wxUI::Menu also allows nesting of menus.  This allows complicated menus to be composed easily.
+`wxUI::Menu` also allows nesting of menus.  This allows complicated menus to be composed easily.
 
 ```cpp
 {{{ examples/HelloWorld/HelloWorld.cpp wxUIMenuSubMenu "    // ..." }}}
@@ -53,7 +53,7 @@ The `wxUI::MenuBar` and related objects are generally "lazy" objects.  They hold
 
 ### Layout
 
-The basics of `wxUI` layout is the "Layout".  You use a specific type of "Layout", with the `VSizer` (Vertical Sizer or "row") and `HSizer` (Horizontal Sizer or "column") being the most common. When a "Layout" is set as the top level, it uses the layout as a sort of "blueprint" for stamping out the UI by constructing the ownership hierarchy and layout.
+The basics of `wxUI` layout is the *Layout*.  You use a specific type of *Layout*, with the `wxUI::VSizer` (Vertical Sizer or "row") and `wxUI::HSizer` (Horizontal Sizer or "column") being the most common. When a *Layout* is set as the top level, it uses the layout as a sort of "blueprint" for stamping out the UI by constructing the ownership hierarchy and layout.
 
 ```cpp
 {{{ examples/HelloWorld/HelloWorld.cpp wxUILayoutBasic "    // ..." }}}
@@ -61,7 +61,7 @@ The basics of `wxUI` layout is the "Layout".  You use a specific type of "Layout
 
 In the above example we have constructed a vertical layout sizer that will use a `wxSizer` with the `wxSizerFlags` set to expand with a default border.  Then the first item in the sizer is a second layer sizer with horizontal layout.  The `wxSizerFlags` are propogated to each layer so the horizontal layout in this example would also be set to expand with a default border.  The second sizer would be created as a "named" box horizonal sizer.
 
-A "Layout" takes a collection of Items, which can be either additional "Layout" (to create a tree of "Layouts") or "Controllers".  Here is the general form of constructions for Sizers:
+A *Layout* takes a collection of objects, which can be either additional *Layout* (to create a tree of *Layouts*) or *Controllers*.  Here is the general form of constructions for *Sizers*:
 
 ```
 Sizer { Items... }
@@ -70,9 +70,9 @@ Sizer { "Name", Items... }
 Sizer { "Name", SizerFlags, Items... }
 ```
 
-`wxUI` supports 3 flavors of Sizers: `VSizer` (Vertical Sizers), `HSizer` (Horizontal Sizers), and `FlexGridSizer` (Flexible Grid Sizers).  Both `VSizer` and `HSizer` can be created with a string to create a "named" box.
+`wxUI` supports 3 flavors of Sizers: `wxUI::VSizer` (Vertical Sizers), `wxUI::HSizer` (Horizontal Sizers), and `wxUI::FlexGridSizer` (Flexible Grid Sizers).  Both `wxUI::VSizer` and `wxUI::HSizer` can be created with a string to create a "named" box.
 
-Note: Because Sizers are intented to be "recursive" data structures, it is possible for a `VSizer` to contain a `VSizer`.  However, be aware that if an empty `VSizer` is created with *just* a `VSizer` as the argument, we collapse that to be a single `VSizer`.  ie, this:
+Note: Because Sizers are intented to be "recursive" data structures, it is possible for a `wxUI::VSizer` to contain a `wxUI::VSizer`.  However, be aware that if an empty `wxUI::VSizer` is created with *just* a `wxUI::VSizer` as the argument, we collapse that to be a single `wxUI::VSizer`.  ie, this:
 
 ```
 wxUI::VSizer { wxUI::VSizer { "Current Frame" } }.attachTo(this);
@@ -87,7 +87,7 @@ wxUI::VSizer { "Current Frame" }.attachTo(this);
 
 #### Generic
 
-One special type of "Layout" is `Generic`.  There are cases where you may have an existing layout as a `wxSizer` (such as a common dialog) or `wxWindow` (such as a custom window) that you wish to use with `wxUI`.  This is a case to use `Generic`:
+One special type of *Layout* is `Generic`.  There are cases where you may have an existing layout as a `wxSizer` (such as a common dialog) or `wxWindow` (such as a custom window) that you wish to use with `wxUI`.  This is a case to use `Generic`:
 
 ```cpp
 {{{ examples/HelloWorld/HelloWorld.cpp wxUIGeneric "    // ..." }}}
@@ -95,13 +95,13 @@ One special type of "Layout" is `Generic`.  There are cases where you may have a
 
 ### Controllers
 
-"Controllers" are the general term to refer to items that behave like a [`wxContol`](https://docs.wxwidgets.org/3.0/classwx_control.html).  In `wxUI` we attempt to conform a consistent style that favors the common things you do with a specific `wxControl`.
+*Controllers* are the general term to refer to items that behave like a [`wxContol`](https://docs.wxwidgets.org/3.0/classwx_control.html).  In `wxUI` we attempt to conform a consistent style that favors the common things you do with a specific `wxControl`.
 
 ```cpp
 {{{ examples/HelloWorld/HelloWorld.cpp wxUIController "    // ..." }}}
 ```
 
-By default "Controllers" are constructed using the default arguments for position, style, size, etc.  "Controllers" are designed to use Method Chaining to specialize the way the controller is constructed.  In the example above we see that `TextCtrl` is being augmented with the style `wxALIGN_LEFT`.
+By default *Controllers* are constructed using the default arguments for position, style, size, etc.  *Controllers* are designed to use [Method Chaining](https://en.wikipedia.org/wiki/Method_chaining) to specialize the way the controller is constructed.  In the example above we see that `wxUI::TextCtrl` is being augmented with the style `wxALIGN_LEFT`.
 
 The list of Methods supported by all controllers:
 
@@ -109,30 +109,9 @@ The list of Methods supported by all controllers:
  * `withSize(wxSize size)` : Specifies the `size` of the `wxControl`.
  * `withStyle(long style)` : Specifies the `style` of the `wxControl`.
 
-The "Controllers" currently supported by `wxUI`:
-
- * `Bitmap` for `wxStaticBitmap`
- * `BitmapButton` for `wxBitmapButton`
- * `BitmapComboBox` for `wxBitmapComboBox`
- * `BitmapToggleButton` for `wxBitmapToggleButton`
- * `Button` for `wxButton`
- * `CheckBox` for `wxCheckBox`
- * `Choice` for `wxChoice`
- * `ComboBox` for `wxComboBox`
- * `Hypertext` for `wxHypertextCtrl`
- * `ListBox` for `wxListBox`
- * `Line` for `wxStaticLine`
- * `RadioBox` for `wxRadioBox`
- * `Slider` for `wxSlider`
- * `SpinCtrl` for `wxSpinCtrl`
- * `Text` for `wxStaticText`
- * `TextCtrl` for `wxTextCtrl`
-
-Additional "Contollers" should be easy to add in future updates.
-
 #### Bind
 
-Some "Controllers" support "Binding" a function call to their event handlers.  When the event for that controller is emitted, the function-like object supplied will be called.
+Some *Controllers* support "binding" a function call to their event handlers.  When the event for that controller is emitted, the function-like object supplied will be called.
 
 ```cpp
 {{{ examples/HelloWorld/HelloWorld.cpp wxUIBind "    // ..." }}}
@@ -140,9 +119,16 @@ Some "Controllers" support "Binding" a function call to their event handlers.  W
 
 For convenience the event parameter of the function can be omitted in cases where it is unused.
 
-#### `getHandle`
+#### Proxy
 
-Often a `wxWindow` object needs to be referenced.  For example, perhaps for reading a currently selected value.  "Controllers" support `getHandle`, a way to get the handle to the underlying `wxWindow` that is created for the "Controller".  You provide the address of the handle that you would like to be populated when the "Controller" is created
+Often the value of a *Controller* in a layout needs to be referenced, or sometimes the backing `wxWindow` itself needs to be used directly.  This could be for reading a currently typed in value in a `TextCtrl`, or to change the selection of a `Choice`.  *Controllers* support `Proxy` objects, a way to get the handle to the underlying `wxWindow` that is created for the *Controller*.
+
+Some *Controllers* do not support values that are intended to change, such as a `Line`, and others can have several values of interest, such as a `ComboBox`.  `Proxy` objects can have several accessors that allow access to these, most commonly called `value()` and `selection()` (see Supported Controllers for details of each supported *Controller*).  These accessors are proxy objects support `get()` and `set()` functions, as well as a set of appropriate overloads for the underlying type, allowing more ergonomic interaction with the code.  `Proxy` also supplies `operator*` and `operator->` which reference the most common accessor.
+
+`Proxy` supply `control()`, which is intended to allow access to the underlying controller.
+
+As `Proxy` objects need to be a named variable that exist outside of a *Controller*, and require being "attached".  This is done with the `operator=`, allowing for an ergonomic way to attach `Proxy` objects to controls.  Accessing a proxy object that has not been attached to a controller will cause an exception to be raised.
+
 
 ```cpp
 auto getHandle(UnderlyingType** handlePtr);
@@ -161,15 +147,36 @@ ExtendedExample::ExtendedExample(wxWindow* parent)
 {
     using namespace wxUI;
     VSizer {
-        TextCtrl { "Hello" }
-            .getHandle(&mText),
-        },
+        proxy = TextCtrl { "Hello" }
     }
         .attachTo(this);
 }
 ```
 
-Note that this handle is non-owning, so it is vital to not have the ptr participate in any lifecycle management of the object.
+#### Supported Controllers
+
+The "Controllers" currently supported by `wxUI`:
+
+| wxUI                 | wxWidget               | Proxy                     | Proxy accessors value |
+| :------------------- | :--------------------- | :------------------------ | :-------------- |
+| `Bitmap`             | `wxStaticBitmap`       | `BitmapProxy`             | n/a             |
+| `BitmapButton`       | `wxBitmapButton`       | `BitmapButtonProxy`       | n/a             |
+| `BitmapComboBox`     | `wxBitmapComboBox`     | `BitmapComboBoxProxy`     | `selection` -> `int`<BR>`value` -> `std::string`<BR>*default*: `value` |
+| `BitmapToggleButton` | `wxBitmapToggleButton` | `BitmapToggleButtonProxy` | `value` -> `bool`<BR>*default*: `value` |
+| `Button`             | `wxButton`             | `ButtonProxy`             | n/a             |
+| `CheckBox`           | `wxCheckBox`           | `CheckBoxProxy`           | `value` -> `bool`<BR>*default*: `value` |
+| `Choice`             | `wxChoice`             | `ChoiceProxy`             | `selection` -> `int`<BR>*default*: `selection` |
+| `ComboBox`           | `wxComboBox`           | `ComboBoxProxy`           | `selection` -> `int`<BR>`value` -> `std::string`<BR>*default*: `value` |
+| `Hypertext`          | `wxHypertextCtrl`      | `HypertextProxy`          | n/a             |
+| `Line`               | `wxStaticLine`         | `LineProxy`               | n/a             |
+| `ListBox`            | `wxListBox`            | `ListBoxProxy`            | `selection` -> `int`<BR>*default*: `selection` |
+| `RadioBox`           | `wxRadioBox`           | `RadioBoxProxy`           | `selection` -> `int`<BR>*default*: `selection` |
+| `Slider`             | `wxSlider`             | `SliderProxy`             | `value` -> `int`<BR>*default*: `value` |
+| `SpinCtrl`           | `wxSpinCtrl`           | `SpinCtrlProxy`           | `value` -> `int`<BR>*default*: `value` |
+| `Text`               | `wxStaticText`         | `TextProxy`               | `label` -> `std::string`<BR>*default*: `label` |
+| `TextCtrl`           | `wxTextCtrl`           | `TextCtrlProxy`           | `label` -> `std::string`<BR>*default*: `label` |
+
+Additional "Contollers" should be easy to add in future updates.
 
 #### Custom
 

--- a/examples/HelloWorld/ExtendedExample.cpp
+++ b/examples/HelloWorld/ExtendedExample.cpp
@@ -26,15 +26,26 @@ SOFTWARE.
 #include "ExtendedExample.h"
 #include <wxUI/wxUI.h>
 
+wxUI::Text::Proxy textProxy;
+wxUI::SpinCtrl::Proxy spinProxy;
 ExtendedExample::ExtendedExample(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, "ExtendedExample",
         wxDefaultPosition, wxDefaultSize,
         wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     using namespace wxUI;
-    wxStaticText* text = nullptr;
     VSizer {
         wxSizerFlags().Expand().Border(),
+        // incr example
+        HSizer {
+            spinProxy.bind(SpinCtrl { std::pair { 1, 3 } }),
+        },
+        HSizer {
+            Button { "Incr" }
+                .bind([]() {
+                    *spinProxy = 1 + *spinProxy;
+                }),
+        },
         HSizer {
             BitmapButton { wxBitmap {} },
         },
@@ -43,6 +54,20 @@ ExtendedExample::ExtendedExample(wxWindow* parent)
         },
         HSizer {
             BitmapToggleButton { wxBitmap {} },
+        },
+        // getHandle example
+        HSizer {
+            textProxy = Text { "Hello" },
+        },
+        HSizer {
+            Button { "ReduceText" }
+                .bind([]() {
+                    auto str = textProxy->get();
+                    if (str.size()) {
+                        str.pop_back();
+                    }
+                    textProxy->set(str);
+                }),
         },
         HSizer {
             Button {},
@@ -74,11 +99,6 @@ ExtendedExample::ExtendedExample(wxWindow* parent)
         HSizer {
             TextCtrl {},
         },
-        // getHandle example
-        HSizer {
-            Text { "Hello" }
-                .getHandle(&text),
-        },
         // bind examples
         HSizer {
             TextCtrl { "Hello" }
@@ -98,10 +118,8 @@ ExtendedExample::ExtendedExample(wxWindow* parent)
                 },
             },
         },
+        Generic { CreateStdDialogButtonSizer(wxOK) },
         // endsnippet CustomExample
     }
-        .attachTo(this);
-    if (text->GetLabel() != "Hello") {
-        throw std::runtime_error("Error, could not create reference");
-    }
+        .attachToAndFit(this);
 }

--- a/include/wxUI/Bitmap.h
+++ b/include/wxUI/Bitmap.h
@@ -28,6 +28,7 @@ SOFTWARE.
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_static_bitmap.html
 struct Bitmap : public details::WidgetDetails<Bitmap, wxStaticBitmap> {
     using super = details::WidgetDetails<Bitmap, wxStaticBitmap>;
 
@@ -58,6 +59,9 @@ struct Bitmap : public details::WidgetDetails<Bitmap, wxStaticBitmap> {
         return new underlying_t(parent, getIdentity(), bitmap, getPos(), getSize(), getStyle());
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+    };
     RULE_OF_SIX_BOILERPLATE(Bitmap);
 
 private:

--- a/include/wxUI/BitmapButton.h
+++ b/include/wxUI/BitmapButton.h
@@ -28,6 +28,7 @@ SOFTWARE.
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_bitmap_button.html
 struct BitmapButton : public details::WidgetDetails<BitmapButton, wxBitmapButton> {
     using super = details::WidgetDetails<BitmapButton, wxBitmapButton>;
 
@@ -74,6 +75,9 @@ struct BitmapButton : public details::WidgetDetails<BitmapButton, wxBitmapButton
         return details::BindWidgetToEvent { *this, wxEVT_BUTTON, func };
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+    };
     RULE_OF_SIX_BOILERPLATE(BitmapButton);
 
 private:

--- a/include/wxUI/BitmapComboBox.h
+++ b/include/wxUI/BitmapComboBox.h
@@ -23,11 +23,13 @@ SOFTWARE.
 */
 #pragma once
 
+#include "GetterSetter.h"
 #include "Widget.h"
 #include <wx/bmpcbox.h>
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_bitmap_combo_box.html
 struct BitmapComboBox : public details::WidgetDetails<BitmapComboBox, wxBitmapComboBox> {
     using super = details::WidgetDetails<BitmapComboBox, wxBitmapComboBox>;
 
@@ -106,6 +108,28 @@ struct BitmapComboBox : public details::WidgetDetails<BitmapComboBox, wxBitmapCo
         return details::BindWidgetToEvent { *this, wxEVT_COMBOBOX, func };
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+        [[nodiscard]] auto value() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return static_cast<std::string>(controller->GetValue()); },
+                [controller](std::string value) { controller->SetValue(value); }
+            };
+        }
+        [[nodiscard]] auto selection() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return controller->GetSelection(); },
+                [controller](int selection) { controller->SetSelection(selection); }
+            };
+        }
+
+        auto operator->() const { return value(); }
+        auto operator*() const { return value(); }
+    };
     RULE_OF_SIX_BOILERPLATE(BitmapComboBox);
 
 private:

--- a/include/wxUI/BitmapToggleButton.h
+++ b/include/wxUI/BitmapToggleButton.h
@@ -23,11 +23,13 @@ SOFTWARE.
 */
 #pragma once
 
+#include "GetterSetter.h"
 #include "Widget.h"
 #include <wx/tglbtn.h>
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_bitmap_toggle_button.html
 struct BitmapToggleButton : public details::WidgetDetails<BitmapToggleButton, wxBitmapToggleButton> {
     using super = details::WidgetDetails<BitmapToggleButton, wxBitmapToggleButton>;
 
@@ -70,6 +72,20 @@ struct BitmapToggleButton : public details::WidgetDetails<BitmapToggleButton, wx
         return details::BindWidgetToEvent { *this, wxEVT_TOGGLEBUTTON, func };
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+        [[nodiscard]] auto value() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return controller->GetValue(); },
+                [controller](bool value) { controller->SetValue(value); }
+            };
+        }
+
+        auto operator->() const { return value(); }
+        auto operator*() const { return value(); }
+    };
     RULE_OF_SIX_BOILERPLATE(BitmapToggleButton);
 
 private:

--- a/include/wxUI/Button.h
+++ b/include/wxUI/Button.h
@@ -28,8 +28,10 @@ SOFTWARE.
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_button.html
 struct Button : public details::WidgetDetails<Button, wxButton> {
     using super = details::WidgetDetails<Button, wxButton>;
+    using details::WidgetDetails<Button, wxButton>::underlying_t;
 
     explicit Button(wxWindowID identity, std::string text = "")
         : super(identity)
@@ -74,6 +76,9 @@ struct Button : public details::WidgetDetails<Button, wxButton> {
         return details::BindWidgetToEvent { *this, wxEVT_BUTTON, func };
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+    };
     RULE_OF_SIX_BOILERPLATE(Button);
 
 private:

--- a/include/wxUI/CheckBox.h
+++ b/include/wxUI/CheckBox.h
@@ -23,11 +23,13 @@ SOFTWARE.
 */
 #pragma once
 
+#include "GetterSetter.h"
 #include "Widget.h"
 #include <wx/checkbox.h>
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_check_box.html
 struct CheckBox : public details::WidgetDetails<CheckBox, wxCheckBox> {
     using super = details::WidgetDetails<CheckBox, wxCheckBox>;
 
@@ -72,6 +74,20 @@ struct CheckBox : public details::WidgetDetails<CheckBox, wxCheckBox> {
         return details::BindWidgetToEvent { *this, wxEVT_CHECKBOX, func };
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+        [[nodiscard]] auto value() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return controller->GetValue(); },
+                [controller](bool value) { controller->SetValue(value); }
+            };
+        }
+
+        auto operator->() const { return value(); }
+        auto operator*() const { return value(); }
+    };
     RULE_OF_SIX_BOILERPLATE(CheckBox);
 
 private:

--- a/include/wxUI/Choice.h
+++ b/include/wxUI/Choice.h
@@ -23,11 +23,13 @@ SOFTWARE.
 */
 #pragma once
 
+#include "GetterSetter.h"
 #include "Widget.h"
 #include <wx/choice.h>
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_choice.html
 struct Choice : public details::WidgetDetails<Choice, wxChoice> {
     using super = details::WidgetDetails<Choice, wxChoice>;
 
@@ -72,6 +74,20 @@ struct Choice : public details::WidgetDetails<Choice, wxChoice> {
         return details::BindWidgetToEvent { *this, wxEVT_CHOICE, func };
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+        [[nodiscard]] auto selection() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return controller->GetSelection(); },
+                [controller](int selection) { controller->SetSelection(selection); }
+            };
+        }
+
+        auto operator->() const { return selection(); }
+        auto operator*() const { return selection(); }
+    };
     RULE_OF_SIX_BOILERPLATE(Choice);
 
 private:

--- a/include/wxUI/ComboBox.h
+++ b/include/wxUI/ComboBox.h
@@ -23,11 +23,13 @@ SOFTWARE.
 */
 #pragma once
 
+#include "GetterSetter.h"
 #include "Widget.h"
 #include <wx/combobox.h>
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_combo_box.html
 struct ComboBox : public details::WidgetDetails<ComboBox, wxComboBox> {
     using super = details::WidgetDetails<ComboBox, wxComboBox>;
 
@@ -73,6 +75,28 @@ struct ComboBox : public details::WidgetDetails<ComboBox, wxComboBox> {
         return details::BindWidgetToEvent { *this, wxEVT_COMBOBOX, func };
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+        [[nodiscard]] auto value() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return static_cast<std::string>(controller->GetValue()); },
+                [controller](std::string value) { controller->SetValue(value); }
+            };
+        }
+        [[nodiscard]] auto selection() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return controller->GetSelection(); },
+                [controller](int selection) { controller->SetSelection(selection); }
+            };
+        }
+
+        auto operator->() const { return value(); }
+        auto operator*() const { return value(); }
+    };
     RULE_OF_SIX_BOILERPLATE(ComboBox);
 
 private:

--- a/include/wxUI/GetterSetter.h
+++ b/include/wxUI/GetterSetter.h
@@ -1,0 +1,447 @@
+/*
+MIT License
+
+Copyright (c) 2022 Richard Powell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#pragma once
+
+#include <functional>
+#include <istream>
+#include <ostream>
+
+namespace wxUI::details {
+
+// why is this Enable here?  Because we need to specialize on the type without over constraining.
+template <typename Type, typename Getter, typename Setter, class Enable = void>
+struct GetterSetter {
+
+    static_assert(std::is_invocable_v<Getter>);
+    static_assert(std::is_invocable_v<Setter, Type>);
+    static_assert(std::is_invocable_v<Setter, std::invoke_result_t<Getter>>);
+
+    explicit GetterSetter(Getter getter, Setter setter)
+        : getter(getter)
+        , setter(setter)
+    {
+    }
+
+    [[nodiscard]] auto get() const -> Type
+    {
+        return getter();
+    }
+
+    // we specifically want implicit conversions for ergonomics
+    // NOLINTNEXTLINE (hicpp-explicit-conversions)
+    operator Type() const
+    {
+        return getter();
+    }
+
+    void set(Type const& value)
+    {
+        setter(value);
+    }
+
+    auto operator=(Type const& value) -> GetterSetter&
+    {
+        setter(value);
+        return *this;
+    }
+
+    auto operator->() -> GetterSetter*
+    {
+        return this;
+    }
+
+    // NOLINTNEXTLINE (readability-identifier-length)
+    friend auto operator<<(std::ostream& os, GetterSetter const& v) -> std::ostream&
+    {
+        return os << v.get();
+    }
+
+    // NOLINTNEXTLINE (readability-identifier-length)
+    friend auto operator>>(std::istream& is, GetterSetter& v) -> std::istream&
+    {
+        auto temp = Type {};
+        is >> temp;
+        v.set(std::move(temp));
+        return is;
+    }
+
+private:
+    Getter getter;
+    Setter setter;
+};
+
+// CTAD for GetterSetter
+template <typename Getter, typename Setter>
+GetterSetter(Getter, Setter) -> GetterSetter<std::invoke_result_t<Getter>, Getter, Setter>;
+
+// Specialize for bool
+
+// This implemention supports logic operations for bools only
+template <typename Getter, typename Setter>
+struct GetterSetter<bool, Getter, Setter> {
+
+    using Type = bool;
+    static_assert(std::is_invocable_v<Getter>);
+    static_assert(std::is_invocable_v<Setter, Type>);
+    static_assert(std::is_invocable_v<Setter, Type>);
+
+    explicit GetterSetter(Getter getter, Setter setter)
+        : getter(getter)
+        , setter(setter)
+    {
+    }
+
+    [[nodiscard]] auto get() const -> Type
+    {
+        return getter();
+    }
+
+    // we specifically want implicit conversions for ergonomics
+    // NOLINTNEXTLINE (hicpp-explicit-conversions)
+    operator Type() const
+    {
+        return getter();
+    }
+
+    void set(Type value)
+    {
+        setter(value);
+    }
+
+    auto operator=(Type value) -> GetterSetter&
+    {
+        setter(value);
+        return *this;
+    }
+
+    auto operator&=(Type value) -> GetterSetter&
+    {
+        setter(getter() & value);
+        return *this;
+    }
+
+    auto operator^=(Type value) -> GetterSetter&
+    {
+        setter(getter() ^ value);
+        return *this;
+    }
+
+    auto operator|=(Type value) -> GetterSetter&
+    {
+        setter(getter() | value);
+        return *this;
+    }
+
+    auto operator->() -> GetterSetter*
+    {
+        return this;
+    }
+
+    // NOLINTNEXTLINE (readability-identifier-length)
+    friend auto operator<<(std::ostream& os, GetterSetter const& v) -> std::ostream&
+    {
+        return os << v.get();
+    }
+
+    // NOLINTNEXTLINE (readability-identifier-length)
+    friend auto operator>>(std::istream& is, GetterSetter& v) -> std::istream&
+    {
+        auto temp = Type {};
+        is >> temp;
+        v.set(temp);
+        return is;
+    }
+
+private:
+    Getter getter;
+    Setter setter;
+};
+
+// Specialize for integral types
+template <class T>
+concept Integral = std::is_integral_v<T>;
+
+template <Integral Type, typename Getter, typename Setter>
+struct GetterSetter<Type, Getter, Setter> {
+
+    static_assert(std::is_invocable_v<Getter>);
+    static_assert(std::is_invocable_v<Setter, Type>);
+    static_assert(std::is_invocable_v<Setter, std::invoke_result_t<Getter>>);
+
+    explicit GetterSetter(Getter getter, Setter setter)
+        : getter(getter)
+        , setter(setter)
+    {
+    }
+
+    [[nodiscard]] auto get() const -> Type
+    {
+        return getter();
+    }
+
+    // we specifically want implicit conversions for ergonomics
+    // NOLINTNEXTLINE (hicpp-explicit-conversions)
+    operator Type() const
+    {
+        return getter();
+    }
+
+    void set(Type value)
+    {
+        setter(value);
+    }
+
+    auto operator=(Type value) -> GetterSetter&
+    {
+        setter(value);
+        return *this;
+    }
+
+    auto operator+=(Type value) -> GetterSetter&
+    {
+        setter(getter() + value);
+        return *this;
+    }
+
+    auto operator-=(Type value) -> GetterSetter&
+    {
+        setter(getter() - value);
+        return *this;
+    }
+
+    auto operator*=(Type value) -> GetterSetter&
+    {
+        setter(getter() * value);
+        return *this;
+    }
+
+    auto operator/=(Type value) -> GetterSetter&
+    {
+        setter(getter() / value);
+        return *this;
+    }
+
+    auto operator%=(Type value) -> GetterSetter&
+    {
+        setter(getter() % value);
+        return *this;
+    }
+
+    auto operator<<=(Type value) -> GetterSetter&
+    {
+        setter(getter() << value);
+        return *this;
+    }
+
+    auto operator>>=(Type value) -> GetterSetter&
+    {
+        setter(getter() >> value);
+        return *this;
+    }
+
+    auto operator&=(Type value) -> GetterSetter&
+    {
+        setter(getter() & value);
+        return *this;
+    }
+
+    auto operator^=(Type value) -> GetterSetter&
+    {
+        setter(getter() ^ value);
+        return *this;
+    }
+
+    auto operator|=(Type value) -> GetterSetter&
+    {
+        setter(getter() | value);
+        return *this;
+    }
+
+    auto operator++() -> GetterSetter&
+    {
+        setter(getter() + 1);
+        return *this;
+    }
+
+    auto operator++(int) -> Type
+    {
+        auto result = getter();
+        setter(result + 1);
+        return result;
+    }
+
+    auto operator--() -> GetterSetter&
+    {
+        setter(getter() - 1);
+        return *this;
+    }
+
+    auto operator--(int) -> Type
+    {
+        auto result = getter();
+        setter(result - 1);
+        return result;
+    }
+
+    auto operator->() -> GetterSetter*
+    {
+        return this;
+    }
+
+    // NOLINTNEXTLINE (readability-identifier-length)
+    friend auto operator<<(std::ostream& os, GetterSetter const& v) -> std::ostream&
+    {
+        return os << v.get();
+    }
+
+    // NOLINTNEXTLINE (readability-identifier-length)
+    friend auto operator>>(std::istream& is, GetterSetter& v) -> std::istream&
+    {
+        auto temp = Type {};
+        is >> temp;
+        v.set(std::move(temp));
+        return is;
+    }
+
+private:
+    Getter getter;
+    Setter setter;
+};
+
+// Specialize for Float types
+template <class T>
+concept FloatingPoint = std::is_floating_point_v<T>;
+
+template <FloatingPoint Type, typename Getter, typename Setter>
+struct GetterSetter<Type, Getter, Setter> {
+
+    static_assert(std::is_invocable_v<Getter>);
+    static_assert(std::is_invocable_v<Setter, Type>);
+    static_assert(std::is_invocable_v<Setter, std::invoke_result_t<Getter>>);
+
+    explicit GetterSetter(Getter getter, Setter setter)
+        : getter(getter)
+        , setter(setter)
+    {
+    }
+
+    [[nodiscard]] auto get() const -> Type
+    {
+        return getter();
+    }
+
+    // we specifically want implicit conversions for ergonomics
+    // NOLINTNEXTLINE (hicpp-explicit-conversions)
+    operator Type() const
+    {
+        return getter();
+    }
+
+    void set(Type value)
+    {
+        setter(value);
+    }
+
+    auto operator=(Type value) -> GetterSetter&
+    {
+        setter(value);
+        return *this;
+    }
+
+    auto operator+=(Type value) -> GetterSetter&
+    {
+        setter(getter() + value);
+        return *this;
+    }
+
+    auto operator-=(Type value) -> GetterSetter&
+    {
+        setter(getter() - value);
+        return *this;
+    }
+
+    auto operator*=(Type value) -> GetterSetter&
+    {
+        setter(getter() * value);
+        return *this;
+    }
+
+    auto operator/=(Type value) -> GetterSetter&
+    {
+        setter(getter() / value);
+        return *this;
+    }
+
+    auto operator++() -> GetterSetter&
+    {
+        setter(getter() + 1);
+        return *this;
+    }
+
+    auto operator++(int) -> Type
+    {
+        auto result = getter();
+        setter(result + 1);
+        return result;
+    }
+
+    auto operator--() -> GetterSetter&
+    {
+        setter(getter() - 1);
+        return *this;
+    }
+
+    auto operator--(int) -> Type
+    {
+        auto result = getter();
+        setter(result - 1);
+        return result;
+    }
+
+    auto operator->() -> GetterSetter*
+    {
+        return this;
+    }
+
+    // NOLINTNEXTLINE (readability-identifier-length)
+    friend auto operator<<(std::ostream& os, GetterSetter const& v) -> std::ostream&
+    {
+        return os << v.get();
+    }
+
+    // NOLINTNEXTLINE (readability-identifier-length)
+    friend auto operator>>(std::istream& is, GetterSetter& v) -> std::istream&
+    {
+        auto temp = Type {};
+        is >> temp;
+        v.set(std::move(temp));
+        return is;
+    }
+
+private:
+    Getter getter;
+    Setter setter;
+};
+
+}

--- a/include/wxUI/Hyperlink.h
+++ b/include/wxUI/Hyperlink.h
@@ -28,6 +28,7 @@ SOFTWARE.
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_hyperlink_ctrl.html
 struct Hyperlink : public details::WidgetDetails<Hyperlink, wxHyperlinkCtrl> {
     using super = details::WidgetDetails<Hyperlink, wxHyperlinkCtrl>;
 
@@ -60,6 +61,9 @@ struct Hyperlink : public details::WidgetDetails<Hyperlink, wxHyperlinkCtrl> {
         return new underlying_t(parent, getIdentity(), text, url, getPos(), getSize(), getStyle());
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+    };
     RULE_OF_SIX_BOILERPLATE(Hyperlink);
 
 private:

--- a/include/wxUI/Line.h
+++ b/include/wxUI/Line.h
@@ -28,6 +28,7 @@ SOFTWARE.
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_static_line.html
 struct Line : public details::WidgetDetails<Line, wxStaticLine> {
     using super = details::WidgetDetails<Line, wxStaticLine>;
 
@@ -46,6 +47,9 @@ struct Line : public details::WidgetDetails<Line, wxStaticLine> {
         return new underlying_t(parent, getIdentity(), getPos(), getSize(), getStyle());
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+    };
     RULE_OF_SIX_BOILERPLATE(Line);
 };
 

--- a/include/wxUI/ListBox.h
+++ b/include/wxUI/ListBox.h
@@ -23,11 +23,13 @@ SOFTWARE.
 */
 #pragma once
 
+#include "GetterSetter.h"
 #include "Widget.h"
 #include <wx/listbox.h>
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_list_box.html
 struct ListBox : public details::WidgetDetails<ListBox, wxListBox> {
     using super = details::WidgetDetails<ListBox, wxListBox>;
 
@@ -72,6 +74,20 @@ struct ListBox : public details::WidgetDetails<ListBox, wxListBox> {
         return details::BindWidgetToEvent { *this, wxEVT_LISTBOX, func };
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+        [[nodiscard]] auto selection() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return controller->GetSelection(); },
+                [controller](int selection) { controller->SetSelection(selection); }
+            };
+        }
+
+        auto operator->() const { return selection(); }
+        auto operator*() const { return selection(); }
+    };
     RULE_OF_SIX_BOILERPLATE(ListBox);
 
 private:

--- a/include/wxUI/RadioBox.h
+++ b/include/wxUI/RadioBox.h
@@ -23,11 +23,13 @@ SOFTWARE.
 */
 #pragma once
 
+#include "GetterSetter.h"
 #include "Widget.h"
 #include <wx/radiobox.h>
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_radio_box.html
 struct RadioBox : details::WidgetDetails<RadioBox, wxRadioBox> {
     using super = details::WidgetDetails<RadioBox, wxRadioBox>;
 
@@ -100,6 +102,20 @@ struct RadioBox : details::WidgetDetails<RadioBox, wxRadioBox> {
         return details::BindWidgetToEvent { *this, wxEVT_RADIOBOX, func };
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+        [[nodiscard]] auto selection() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return controller->GetSelection(); },
+                [controller](int selection) { controller->SetSelection(selection); }
+            };
+        }
+
+        auto operator->() const { return selection(); }
+        auto operator*() const { return selection(); }
+    };
     RULE_OF_SIX_BOILERPLATE(RadioBox);
 
 private:

--- a/include/wxUI/Slider.h
+++ b/include/wxUI/Slider.h
@@ -23,11 +23,13 @@ SOFTWARE.
 */
 #pragma once
 
+#include "GetterSetter.h"
 #include "Widget.h"
 #include <wx/slider.h>
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_slider.html
 struct Slider : public details::WidgetDetails<Slider, wxSlider> {
     using super = details::WidgetDetails<Slider, wxSlider>;
 
@@ -70,6 +72,20 @@ struct Slider : public details::WidgetDetails<Slider, wxSlider> {
         return details::BindWidgetToEvent { *this, wxEVT_SLIDER, func };
     }
 
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+        [[nodiscard]] auto value() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return controller->GetValue(); },
+                [controller](int value) { controller->SetValue(value); }
+            };
+        }
+
+        auto operator->() const { return value(); }
+        auto operator*() const { return value(); }
+    };
     RULE_OF_SIX_BOILERPLATE(Slider);
 
 private:

--- a/include/wxUI/Text.h
+++ b/include/wxUI/Text.h
@@ -23,11 +23,13 @@ SOFTWARE.
 */
 #pragma once
 
+#include "GetterSetter.h"
 #include "Widget.h"
 #include <wx/stattext.h>
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_text.html
 struct Text : public details::WidgetDetails<Text, wxStaticText> {
     using super = details::WidgetDetails<Text, wxStaticText>;
 
@@ -57,8 +59,24 @@ struct Text : public details::WidgetDetails<Text, wxStaticText> {
 
     auto create(wxWindow* parent) -> wxWindow* override
     {
-        return new underlying_t(parent, getIdentity(), text, getPos(), getSize(), getStyle());
+        return setProxy(new underlying_t(parent, getIdentity(), text, getPos(), getSize(), getStyle()));
     }
+
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+
+        [[nodiscard]] auto label() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return static_cast<std::string>(controller->GetLabel()); },
+                [controller](std::string label) { controller->SetLabel(label); }
+            };
+        }
+
+        auto operator->() const { return label(); }
+        auto operator*() const { return label(); }
+    };
 
     RULE_OF_SIX_BOILERPLATE(Text);
 

--- a/include/wxUI/TextCtrl.h
+++ b/include/wxUI/TextCtrl.h
@@ -23,11 +23,13 @@ SOFTWARE.
 */
 #pragma once
 
+#include "GetterSetter.h"
 #include "Widget.h"
 #include <wx/textctrl.h>
 
 namespace wxUI {
 
+// https://docs.wxwidgets.org/latest/classwx_text_ctrl.html
 struct TextCtrl : public details::WidgetDetails<TextCtrl, wxTextCtrl> {
     using super = details::WidgetDetails<TextCtrl, wxTextCtrl>;
 
@@ -63,6 +65,22 @@ struct TextCtrl : public details::WidgetDetails<TextCtrl, wxTextCtrl> {
     {
         return details::BindWidgetToEvent { *this, wxEVT_TEXT, func };
     }
+
+    struct Proxy : super::WidgetProxy {
+        PROXY_BOILERPLATE();
+
+        [[nodiscard]] auto label() const
+        {
+            auto* controller = control();
+            return details::GetterSetter {
+                [controller] { return static_cast<std::string>(controller->GetLabel()); },
+                [controller](std::string label) { controller->SetLabel(label); }
+            };
+        }
+
+        auto operator->() const { return label(); }
+        auto operator*() const { return label(); }
+    };
 
     RULE_OF_SIX_BOILERPLATE(TextCtrl);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(wxUI_Tests
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_CheckBoxTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_ChoiceTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_ComboBoxTests.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_GetterSetterTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_HyperlinkTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_LayoutTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_LineTests.cpp

--- a/tests/wxUI_BitmapButtonTests.cpp
+++ b/tests/wxUI_BitmapButtonTests.cpp
@@ -24,16 +24,31 @@ SOFTWARE.
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/BitmapButton.h>
 
+#include "wxUI_TestControlCommon.h"
+
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::BitmapButton;
+
+struct BitmapButtonTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest { wxBitmap {} }; }
+    static auto testStyle() { return (wxBU_LEFT | wxBU_EXACTFIT | wxBU_NOTEXT); }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return BitmapButtonTestPolicy::createUUT(); }
+
 TEST_CASE("BitmapButton")
 {
     SECTION("bitmap")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { wxBitmap {} };
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
     }
@@ -67,7 +82,7 @@ TEST_CASE("BitmapButton")
     SECTION("style")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { wxBitmap {} }.withStyle(wxBU_LEFT);
+        auto uut = createUUT().withStyle(wxBU_LEFT);
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetWindowStyle() == (wxBU_LEFT | wxBU_EXACTFIT | wxBU_NOTEXT));
     }
@@ -75,7 +90,7 @@ TEST_CASE("BitmapButton")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { wxBitmap {} }.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -83,9 +98,11 @@ TEST_CASE("BitmapButton")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { wxBitmap {} }.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
+
+    CHAINING_TEST(BitmapButtonTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_BitmapComboBoxTests.cpp
+++ b/tests/wxUI_BitmapComboBoxTests.cpp
@@ -21,19 +21,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/BitmapComboBox.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::BitmapComboBox;
+
+struct BitmapComboBoxTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest { { { wxString {}, wxBitmap {} } } }; }
+    static auto testStyle() { return (wxCB_SORT); }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return BitmapComboBoxTestPolicy::createUUT(); }
+
 TEST_CASE("BitmapComboBox")
 {
     SECTION("bitmap")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { { { wxString {}, wxBitmap {} } } };
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
     }
@@ -67,7 +81,7 @@ TEST_CASE("BitmapComboBox")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { { { wxString {}, wxBitmap {} } } }.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -75,7 +89,7 @@ TEST_CASE("BitmapComboBox")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { { { wxString {}, wxBitmap {} } } }.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
@@ -91,5 +105,7 @@ TEST_CASE("BitmapComboBox")
         CHECK("Hello" == window->GetString(0));
         CHECK("Goodbye" == window->GetString(1));
     }
+
+    CHAINING_TEST(BitmapComboBoxTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_BitmapTests.cpp
+++ b/tests/wxUI_BitmapTests.cpp
@@ -21,20 +21,35 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/Bitmap.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Bitmap;
+
+struct BitmapTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest { wxBitmap {} }; }
+    static auto testStyle() { return (0); }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return BitmapTestPolicy::createUUT(); }
 
 TEST_CASE("Bitmap")
 {
     SECTION("bitmap")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { wxBitmap {} };
+        auto uut = createUUT();
+        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
+        CHECK(window != nullptr);
     }
 
     SECTION("id.bitmap")
@@ -60,5 +75,7 @@ TEST_CASE("Bitmap")
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(10000 == window->GetId());
     }
+
+    CHAINING_TEST(BitmapTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_BitmapToggleButtonTests.cpp
+++ b/tests/wxUI_BitmapToggleButtonTests.cpp
@@ -21,19 +21,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/BitmapToggleButton.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::BitmapToggleButton;
+
+struct BitmapToggleButtonTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest { wxBitmap {} }; }
+    static auto testStyle() { return (wxBU_LEFT | wxBU_EXACTFIT | wxBU_NOTEXT); }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return BitmapToggleButtonTestPolicy::createUUT(); }
+
 TEST_CASE("BitmapToggleButton")
 {
     SECTION("bitmap")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { wxBitmap {} };
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
     }
@@ -101,7 +115,7 @@ TEST_CASE("BitmapToggleButton")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { wxBitmap {} }.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -109,9 +123,11 @@ TEST_CASE("BitmapToggleButton")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { wxBitmap {} }.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
+
+    CHAINING_TEST(BitmapToggleButtonTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_ButtonTests.cpp
+++ b/tests/wxUI_ButtonTests.cpp
@@ -21,19 +21,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/Button.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Button;
+
+struct ButtonTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest {}; }
+    static auto testStyle() { return (wxBU_LEFT | wxBU_EXACTFIT | wxBU_NOTEXT); }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return ButtonTestPolicy::createUUT(); }
+
 TEST_CASE("Button")
 {
     SECTION("noargs.1")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        TypeUnderTest uut {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
         uut.withPosition(wxPoint {});
@@ -41,7 +55,7 @@ TEST_CASE("Button")
     SECTION("noargs")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
     }
@@ -109,7 +123,7 @@ TEST_CASE("Button")
     SECTION("style")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withStyle(wxBU_LEFT);
+        auto uut = createUUT().withStyle(wxBU_LEFT);
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetWindowStyle() == wxBU_LEFT);
     }
@@ -117,7 +131,7 @@ TEST_CASE("Button")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -125,9 +139,11 @@ TEST_CASE("Button")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
+
+    CHAINING_TEST(ButtonTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_CheckBoxTests.cpp
+++ b/tests/wxUI_CheckBoxTests.cpp
@@ -21,27 +21,40 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/CheckBox.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::CheckBox;
+
+struct CheckBoxTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest {}; }
+    static auto testStyle() { return (wxCHK_3STATE); }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return CheckBoxTestPolicy::createUUT(); }
 
 TEST_CASE("CheckBox")
 {
     SECTION("noargs.1")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        TypeUnderTest uut {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
     }
     SECTION("noargs")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
     }
@@ -109,7 +122,7 @@ TEST_CASE("CheckBox")
     SECTION("style")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withStyle(wxCHK_3STATE);
+        auto uut = createUUT().withStyle(wxCHK_3STATE);
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetWindowStyle() == wxCHK_3STATE);
     }
@@ -117,7 +130,7 @@ TEST_CASE("CheckBox")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -125,9 +138,11 @@ TEST_CASE("CheckBox")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
+
+    CHAINING_TEST(CheckBoxTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_ChoiceTests.cpp
+++ b/tests/wxUI_ChoiceTests.cpp
@@ -21,27 +21,40 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/Choice.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Choice;
+
+struct ChoiceTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest {}; }
+    static auto testStyle() { return (wxCB_SORT); }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return ChoiceTestPolicy::createUUT(); }
 
 TEST_CASE("Choice")
 {
     SECTION("noargs.1")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        TypeUnderTest uut {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(0 == window->GetCount());
     }
     SECTION("noargs")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(0 == window->GetCount());
     }
@@ -133,7 +146,7 @@ TEST_CASE("Choice")
     SECTION("style")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withStyle(wxCB_SORT);
+        auto uut = createUUT().withStyle(wxCB_SORT);
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetWindowStyle() == wxCB_SORT);
     }
@@ -141,7 +154,7 @@ TEST_CASE("Choice")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -149,9 +162,11 @@ TEST_CASE("Choice")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
+
+    CHAINING_TEST(ChoiceTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_ComboBoxTests.cpp
+++ b/tests/wxUI_ComboBoxTests.cpp
@@ -21,19 +21,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/ComboBox.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::ComboBox;
+
+struct ComboBoxTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest { { wxString {} } }; }
+    static auto testStyle() { return (wxCB_DROPDOWN | wxCB_READONLY); }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return ComboBoxTestPolicy::createUUT(); }
+
 TEST_CASE("ComboBox")
 {
     SECTION("choice")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { { wxString {} } };
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
     }
@@ -67,7 +81,7 @@ TEST_CASE("ComboBox")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { { wxString {} } }.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -75,7 +89,7 @@ TEST_CASE("ComboBox")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { { wxString {} } }.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
@@ -91,5 +105,7 @@ TEST_CASE("ComboBox")
         CHECK("Hello" == window->GetString(0));
         CHECK("Goodbye" == window->GetString(1));
     }
+
+    CHAINING_TEST(ComboBoxTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_GetterSetterTests.cpp
+++ b/tests/wxUI_GetterSetterTests.cpp
@@ -1,0 +1,600 @@
+/*
+MIT License
+
+Copyright (c) 2022 Richard Powell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#include <catch2/catch_test_macros.hpp>
+#include <sstream>
+#include <wxUI/GetterSetter.h>
+
+#include <wx/wx.h>
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, cppcoreguidelines-avoid-do-while, readability-magic-numbers, readability-function-cognitive-complexity, hicpp-function-size, misc-use-anonymous-namespace)
+#define BASIC_CHECK()                                   \
+    do {                                                \
+        CHECK(value == checkValue);                     \
+        CHECK(getterCallCount == checkGetterCallCount); \
+        CHECK(setterCallCount == checkSetterCallCount); \
+    } while (0)
+
+TEST_CASE("GetterSetter")
+{
+    SECTION("basics")
+    {
+        auto getterCallCount = int {};
+        auto setterCallCount = int {};
+        auto value = int {};
+
+        auto uut = wxUI::details::GetterSetter {
+            [&] {
+                ++getterCallCount;
+                return value;
+            },
+            [&](int v) {
+                ++setterCallCount;
+                value = v;
+            }
+        };
+        // Basic check
+        CHECK(value == 0);
+        CHECK(getterCallCount == 0);
+        CHECK(setterCallCount == 0);
+
+        CHECK(0 == uut.get());
+
+        CHECK(value == 0);
+        CHECK(getterCallCount == 1);
+        CHECK(setterCallCount == 0);
+
+        uut.set(1);
+
+        CHECK(value == 1);
+        CHECK(getterCallCount == 1);
+        CHECK(setterCallCount == 1);
+
+        // Operator check
+        CHECK(1 == static_cast<int>(uut));
+
+        CHECK(value == 1);
+        CHECK(getterCallCount == 2);
+        CHECK(setterCallCount == 1);
+
+        uut = 2;
+
+        CHECK(value == 2);
+        CHECK(getterCallCount == 2);
+        CHECK(setterCallCount == 2);
+
+        auto ostream = std::ostringstream {};
+        ostream << uut;
+    };
+
+    SECTION("strings")
+    {
+        auto setterCallCount = int {};
+        auto getterCallCount = int {};
+        auto value = std::string { "hello" };
+
+        auto checkGetterCallCount = int {};
+        auto checkSetterCallCount = int {};
+        auto checkValue = std::string { "hello" };
+
+        auto uut = wxUI::details::GetterSetter {
+            [&] {
+                ++getterCallCount;
+                return value;
+            },
+            [&](std::string v) {
+                ++setterCallCount;
+                value = v;
+            }
+        };
+
+        BASIC_CHECK();
+
+        CHECK("hello" == uut.get());
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        // << and >>
+        auto ostream = std::ostringstream {};
+        ostream << uut;
+        checkGetterCallCount += 1;
+
+        CHECK(ostream.str() == "hello");
+
+        BASIC_CHECK();
+
+        auto istream = std::istringstream { "test1\ntest2" };
+        istream >> uut;
+        checkSetterCallCount += 1;
+        checkValue = "test1";
+
+        BASIC_CHECK();
+    };
+
+    SECTION("ints")
+    {
+        auto getterCallCount = int {};
+        auto setterCallCount = int {};
+        auto value = int {};
+
+        auto checkGetterCallCount = int {};
+        auto checkSetterCallCount = int {};
+        auto checkValue = int {};
+
+        auto uut = wxUI::details::GetterSetter {
+            [&] {
+                ++getterCallCount;
+                return value;
+            },
+            [&](int v) {
+                ++setterCallCount;
+                value = v;
+            }
+        };
+        BASIC_CHECK();
+
+        CHECK(0 == uut.get());
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        uut.set(1);
+        checkSetterCallCount += 1;
+        checkValue = 1;
+
+        BASIC_CHECK();
+
+        // Operator check
+        CHECK(1 == static_cast<int>(uut));
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        uut = 2;
+        checkSetterCallCount += 1;
+        checkValue = 2;
+
+        BASIC_CHECK();
+
+        // comparisions
+        CHECK(2 == uut);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(1 != uut);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(3 > uut);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(2 >= uut);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(1 < uut);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(2 <= uut);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(uut == 2);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(uut != 1);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(uut < 3);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(uut <= 2);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(uut > 1);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(uut >= 2);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        // compound assignments
+        uut += 1;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue += 1;
+
+        BASIC_CHECK();
+
+        uut -= 1;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue -= 1;
+
+        BASIC_CHECK();
+
+        uut *= 2;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue *= 2;
+
+        BASIC_CHECK();
+
+        uut /= 2;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue /= 2;
+
+        BASIC_CHECK();
+
+        value = 10;
+        uut %= 7;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = 3;
+
+        BASIC_CHECK();
+
+        value = 2;
+        uut <<= 2;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = 8;
+
+        BASIC_CHECK();
+
+        uut >>= 2;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = 2;
+
+        BASIC_CHECK();
+
+        uut |= 4;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = 6;
+
+        BASIC_CHECK();
+
+        uut &= 4;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = 4;
+
+        BASIC_CHECK();
+
+        uut ^= 6;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = 2;
+
+        BASIC_CHECK();
+
+        // chaining
+        value = 3;
+        auto t = 2 + (uut = 5);
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = 5;
+
+        CHECK(t == 7);
+        BASIC_CHECK();
+
+        // increment decrement
+        value = 3;
+        t = uut++;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = 4;
+
+        CHECK(t == 3);
+        BASIC_CHECK();
+
+        t = ++uut;
+        // this increments by 2 because there's the getter for ++ and then for the assignment to t
+        checkGetterCallCount += 2;
+        checkSetterCallCount += 1;
+        checkValue = 5;
+
+        CHECK(t == 5);
+        BASIC_CHECK();
+
+        t = uut--;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = 4;
+
+        CHECK(t == 5);
+        BASIC_CHECK();
+        t = --uut;
+        // this increments by 2 because there's the getter for -- and then for the assignment to t
+        checkGetterCallCount += 2;
+        checkSetterCallCount += 1;
+        checkValue = 3;
+
+        CHECK(t == 3);
+        BASIC_CHECK();
+
+        // << and >>
+        auto ostream = std::ostringstream {};
+        ostream << uut;
+        checkGetterCallCount += 1;
+
+        CHECK(ostream.str() == "3");
+        BASIC_CHECK();
+
+        auto istream = std::istringstream { "2\n3.5" };
+        istream >> uut;
+        checkSetterCallCount += 1;
+        checkValue = 2;
+
+        BASIC_CHECK();
+
+        istream >> uut;
+        checkSetterCallCount += 1;
+        checkValue = 3;
+
+        BASIC_CHECK();
+    };
+
+    SECTION("bools")
+    {
+        auto getterCallCount = int {};
+        auto setterCallCount = int {};
+        auto value = bool {};
+
+        auto checkGetterCallCount = int {};
+        auto checkSetterCallCount = int {};
+        auto checkValue = bool {};
+
+        auto uut = wxUI::details::GetterSetter {
+            [&] {
+                ++getterCallCount;
+                return value;
+            },
+            [&](bool v) {
+                ++setterCallCount;
+                value = v;
+            }
+        };
+        BASIC_CHECK();
+
+        CHECK(false == uut.get());
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        uut.set(true);
+        checkSetterCallCount += 1;
+        checkValue = 1;
+
+        BASIC_CHECK();
+
+        // Operator check
+        CHECK(true == static_cast<bool>(uut));
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        uut = false;
+        checkSetterCallCount += 1;
+        checkValue = false;
+
+        BASIC_CHECK();
+
+        // comparisions
+        CHECK(false == uut);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(true != uut);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(true > uut);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(false >= uut);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        value = true;
+        CHECK(false < uut);
+        checkGetterCallCount += 1;
+        checkValue = true;
+
+        BASIC_CHECK();
+
+        CHECK(true <= uut);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(uut == true);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        CHECK(uut != false);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        value = false;
+        CHECK(uut < true);
+        checkGetterCallCount += 1;
+        checkValue = false;
+
+        BASIC_CHECK();
+
+        CHECK(uut <= false);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        value = true;
+        CHECK(uut > false);
+        checkGetterCallCount += 1;
+        checkValue = true;
+
+        BASIC_CHECK();
+
+        CHECK(uut >= true);
+        checkGetterCallCount += 1;
+
+        BASIC_CHECK();
+
+        // compound assignments
+        value = true;
+        uut |= true;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = true;
+
+        BASIC_CHECK();
+
+        uut &= false;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = false;
+
+        BASIC_CHECK();
+
+        uut ^= true;
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = true;
+
+        BASIC_CHECK();
+
+        // chaining
+        value = true;
+        auto t = true && (uut = false);
+        checkGetterCallCount += 1;
+        checkSetterCallCount += 1;
+        checkValue = false;
+
+        CHECK(t == false);
+        BASIC_CHECK();
+
+        // << and >>
+        auto ostream = std::ostringstream {};
+        ostream << uut;
+        checkGetterCallCount += 1;
+
+        CHECK(ostream.str() == "0");
+        BASIC_CHECK();
+
+        auto istream = std::istringstream { "1\n0" };
+        istream >> uut;
+        checkSetterCallCount += 1;
+        checkValue = true;
+
+        BASIC_CHECK();
+
+        istream >> uut;
+        checkSetterCallCount += 1;
+        checkValue = false;
+
+        BASIC_CHECK();
+    };
+
+    SECTION("floats")
+    {
+        auto getterCallCount = int {};
+        auto setterCallCount = int {};
+        auto value = float {};
+
+        auto checkGetterCallCount = int {};
+        auto checkSetterCallCount = int {};
+        auto checkValue = float {};
+
+        auto uut = wxUI::details::GetterSetter {
+            [&] {
+                ++getterCallCount;
+                return value;
+            },
+            [&](float v) {
+                ++setterCallCount;
+                value = v;
+            }
+        };
+        // Basic check
+        BASIC_CHECK();
+
+        uut = 2.5;
+        checkSetterCallCount += 1;
+        checkValue = 2.5;
+
+        BASIC_CHECK();
+
+        // << and >>
+        auto ostream = std::ostringstream {};
+        ostream << uut;
+        checkGetterCallCount += 1;
+
+        CHECK(ostream.str() == "2.5");
+        BASIC_CHECK();
+
+        auto istream = std::istringstream { "2\n3.5" };
+        istream >> uut;
+        checkSetterCallCount += 1;
+        checkValue = 2.0;
+
+        BASIC_CHECK();
+
+        istream >> uut;
+        checkSetterCallCount += 1;
+        checkValue = 3.5;
+
+        BASIC_CHECK();
+    }
+    // put all the negative tests here.
+}
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, cppcoreguidelines-avoid-do-while, readability-magic-numbers, readability-function-cognitive-complexity, hicpp-function-size, misc-use-anonymous-namespace)

--- a/tests/wxUI_HyperlinkTests.cpp
+++ b/tests/wxUI_HyperlinkTests.cpp
@@ -21,19 +21,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/Hyperlink.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Hyperlink;
+
+struct HyperlinkTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest { "Hello", "www.github.com" }; }
+    static auto testStyle() { return wxHL_CONTEXTMENU; }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return HyperlinkTestPolicy::createUUT(); }
+
 TEST_CASE("Hyperlink")
 {
     SECTION("name.url")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { "Hello", "www.github.com" };
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK("Hello" == window->GetLabel());
         CHECK("www.github.com" == window->GetURL());
@@ -71,7 +85,7 @@ TEST_CASE("Hyperlink")
     SECTION("style")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { "Hello", "www.github.com" }.withStyle(wxHL_ALIGN_LEFT | wxHL_CONTEXTMENU);
+        auto uut = createUUT().withStyle(wxHL_ALIGN_LEFT | wxHL_CONTEXTMENU);
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetWindowStyle() == (wxHL_ALIGN_LEFT | wxHL_CONTEXTMENU));
     }
@@ -79,7 +93,7 @@ TEST_CASE("Hyperlink")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { "Hello", "www.github.com" }.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -87,9 +101,11 @@ TEST_CASE("Hyperlink")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { "Hello", "www.github.com" }.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
+
+    CHAINING_TEST(HyperlinkTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_LineTests.cpp
+++ b/tests/wxUI_LineTests.cpp
@@ -21,20 +21,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/Line.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Line;
+
+struct LineTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest {}; }
+    static auto testStyle() { return wxLI_VERTICAL; }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return LineTestPolicy::createUUT(); }
 
 TEST_CASE("Line")
 {
     SECTION("noargs")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window != nullptr);
     }
@@ -62,5 +75,7 @@ TEST_CASE("Line")
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(10000 == window->GetId());
     }
+
+    CHAINING_TEST(LineTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_ListBoxTests.cpp
+++ b/tests/wxUI_ListBoxTests.cpp
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/ListBox.h>
 
@@ -29,19 +30,31 @@ SOFTWARE.
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
 using TypeUnderTest = wxUI::ListBox;
 
+struct ListBoxTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest {}; }
+    static auto testStyle() { return wxLB_ALWAYS_SB | wxLB_MULTIPLE; }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return ListBoxTestPolicy::createUUT(); }
+
 TEST_CASE("ListBox")
 {
     SECTION("noargs.1")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        TypeUnderTest uut {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(0 == window->GetCount());
     }
     SECTION("noargs")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(0 == window->GetCount());
     }
@@ -133,7 +146,7 @@ TEST_CASE("ListBox")
     SECTION("style")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withStyle(wxLB_MULTIPLE);
+        auto uut = createUUT().withStyle(wxLB_MULTIPLE);
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetWindowStyle() == (wxBORDER_SUNKEN | wxLB_MULTIPLE));
     }
@@ -141,9 +154,11 @@ TEST_CASE("ListBox")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
+
+    CHAINING_TEST(ListBoxTestPolicy)
 }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)

--- a/tests/wxUI_RadioBoxTests.cpp
+++ b/tests/wxUI_RadioBoxTests.cpp
@@ -21,20 +21,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/RadioBox.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::RadioBox;
+
+struct RadioBoxTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest { std::vector<wxString> { "Hello", "Goodbye" } }; }
+    static auto testStyle() { return wxRA_SPECIFY_COLS; }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return RadioBoxTestPolicy::createUUT(); }
 
 TEST_CASE("RadioBox")
 {
     SECTION("choices")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { std::vector<wxString> { "Hello", "Goodbye" } };
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
         CHECK(2 == window->GetCount());
@@ -134,7 +147,7 @@ TEST_CASE("RadioBox")
     SECTION("style")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { std::vector<wxString> { "Hello", "Goodbye" } }.withStyle(wxRA_SPECIFY_COLS);
+        auto uut = createUUT().withStyle(wxRA_SPECIFY_COLS);
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetWindowStyle() == (wxRA_SPECIFY_COLS | wxTAB_TRAVERSAL));
     }
@@ -142,7 +155,7 @@ TEST_CASE("RadioBox")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { std::vector<wxString> { "Hello", "Goodbye" } }.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -150,9 +163,11 @@ TEST_CASE("RadioBox")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest { std::vector<wxString> { "Hello", "Goodbye" } }.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
+
+    CHAINING_TEST(RadioBoxTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_SliderTests.cpp
+++ b/tests/wxUI_SliderTests.cpp
@@ -21,19 +21,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/Slider.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Slider;
+
+struct SliderTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest {}; }
+    static auto testStyle() { return wxSL_LABELS; }
+    static auto testPosition() { return wxPoint { 14, 2 }; }
+    static auto testSize() { return wxSize { 100, 40 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return wxPoint { 18, 2 }; }
+    static auto expectedSize() { return wxSize { 85, 40 }; }
+};
+static auto createUUT() { return SliderTestPolicy::createUUT(); }
+
 TEST_CASE("Slider")
 {
     SECTION("noargs")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetValue() == 0);
     }
@@ -131,5 +145,7 @@ TEST_CASE("Slider")
         CHECK(10000 == window->GetId());
         CHECK(window->GetValue() == 3);
     }
+
+    CHAINING_TEST(SliderTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_SpinCtrlTests.cpp
+++ b/tests/wxUI_SpinCtrlTests.cpp
@@ -21,19 +21,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/SpinCtrl.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::SpinCtrl;
+
+struct SpinCtrlTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest {}; }
+    static auto testStyle() { return wxTE_PROCESS_ENTER; }
+    static auto testPosition() { return wxPoint { 5, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return SpinCtrlTestPolicy::createUUT(); }
+
 TEST_CASE("SpinCtrl")
 {
     SECTION("noargs")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetValue() == 0);
     }
@@ -135,7 +149,7 @@ TEST_CASE("SpinCtrl")
     SECTION("style")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withStyle(wxTE_PROCESS_ENTER);
+        auto uut = createUUT().withStyle(wxTE_PROCESS_ENTER);
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetWindowStyle() == (wxTE_PROCESS_ENTER | wxTAB_TRAVERSAL | 0x200000));
     }
@@ -143,7 +157,7 @@ TEST_CASE("SpinCtrl")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -151,9 +165,27 @@ TEST_CASE("SpinCtrl")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
+
+    SECTION("proxy")
+    {
+        wxFrame frame { nullptr, wxID_ANY, "" };
+        auto proxy = TypeUnderTest::Proxy {};
+        auto uut = proxy = createUUT().withSize({ 1, 2 });
+        uut.create(&frame);
+
+        CHECK(proxy->get() == 0);
+        proxy->set(1);
+        CHECK(proxy->get() == 1);
+        *proxy = 2;
+        CHECK(proxy->get() == 2);
+        int result2 = *proxy;
+        CHECK(result2 == 2);
+    }
+
+    CHAINING_TEST(SpinCtrlTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_TestControlCommon.h
+++ b/tests/wxUI_TestControlCommon.h
@@ -1,0 +1,103 @@
+/*
+MIT License
+
+Copyright (c) 2022 Richard Powell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#include <catch2/catch_test_macros.hpp>
+#include <wx/wx.h>
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+
+constexpr auto addWithStyle = [](auto style, auto&& inUUT) {
+    return inUUT.withStyle(style);
+};
+
+constexpr auto addWithPosition = [](auto pos, auto&& inUUT) {
+    return inUUT.withPosition(pos);
+};
+
+constexpr auto addWithSize = [](auto size, auto&& inUUT) {
+    return inUUT.withSize(size);
+};
+
+constexpr auto checkWithStyle = [](auto style, auto* window) {
+    CHECK((window->GetWindowStyle() & style) == style);
+    return window;
+};
+
+constexpr auto checkWithPosition = [](auto pos, auto* window) {
+    CHECK(window->GetPosition() == pos);
+    return window;
+};
+
+constexpr auto checkWithSize = [](auto size, auto* window) {
+    CHECK(window->GetSize() == size);
+    return window;
+};
+
+constexpr auto checkAll = [](auto* window, auto style, auto pos, auto size) {
+    return checkWithStyle(style, checkWithPosition(pos, checkWithSize(size, window)));
+};
+
+// How do we test chaining?
+template <typename WHICH>
+auto DoChainingIterations()
+{
+    auto style = WHICH::testStyle();
+    auto pos = WHICH::testPosition();
+    auto size = WHICH::testSize();
+    auto expectedStyle = WHICH::expectedStyle();
+    auto expectedPos = WHICH::expectedPosition();
+    auto expectedSize = WHICH::expectedSize();
+    wxFrame frame { nullptr, wxID_ANY, "" };
+    {
+        auto uut = addWithStyle(style, addWithPosition(pos, addWithSize(size, WHICH::createUUT())));
+        checkAll(dynamic_cast<typename WHICH::TypeUnderTest::underlying_t*>(uut.create(&frame)), expectedStyle, expectedPos, expectedSize);
+    }
+    {
+        auto uut = addWithPosition(pos, addWithStyle(style, addWithSize(size, WHICH::createUUT())));
+        checkAll(dynamic_cast<typename WHICH::TypeUnderTest::underlying_t*>(uut.create(&frame)), expectedStyle, expectedPos, expectedSize);
+    }
+    {
+        auto uut = addWithSize(size, addWithStyle(style, addWithPosition(pos, WHICH::createUUT())));
+        checkAll(dynamic_cast<typename WHICH::TypeUnderTest::underlying_t*>(uut.create(&frame)), expectedStyle, expectedPos, expectedSize);
+    }
+    {
+        auto uut = addWithStyle(style, addWithSize(size, addWithPosition(pos, WHICH::createUUT())));
+        checkAll(dynamic_cast<typename WHICH::TypeUnderTest::underlying_t*>(uut.create(&frame)), expectedStyle, expectedPos, expectedSize);
+    }
+    {
+        auto uut = addWithPosition(pos, addWithSize(size, addWithStyle(style, WHICH::createUUT())));
+        checkAll(dynamic_cast<typename WHICH::TypeUnderTest::underlying_t*>(uut.create(&frame)), expectedStyle, expectedPos, expectedSize);
+    }
+    {
+        auto uut = addWithSize(size, addWithPosition(pos, addWithStyle(style, WHICH::createUUT())));
+        checkAll(dynamic_cast<typename WHICH::TypeUnderTest::underlying_t*>(uut.create(&frame)), expectedStyle, expectedPos, expectedSize);
+    }
+}
+
+#define CHAINING_TEST(WHICH)           \
+    SECTION("check all iterations")    \
+    {                                  \
+        DoChainingIterations<WHICH>(); \
+    }
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)

--- a/tests/wxUI_TextCtrlTests.cpp
+++ b/tests/wxUI_TextCtrlTests.cpp
@@ -21,26 +21,40 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/TextCtrl.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::TextCtrl;
+
+struct TextCtrlTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest {}; }
+    static auto testStyle() { return wxTE_PROCESS_ENTER; }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return TextCtrlTestPolicy::createUUT(); }
+
 TEST_CASE("TextCtrl")
 {
     SECTION("noargs.1")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        TypeUnderTest uut {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
     }
     SECTION("noargs")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
     }
@@ -108,7 +122,7 @@ TEST_CASE("TextCtrl")
     SECTION("style")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withStyle(wxTE_PROCESS_ENTER);
+        auto uut = createUUT().withStyle(wxTE_PROCESS_ENTER);
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetWindowStyle() == (wxBORDER_SUNKEN | wxTE_PROCESS_ENTER));
     }
@@ -116,7 +130,7 @@ TEST_CASE("TextCtrl")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -124,9 +138,11 @@ TEST_CASE("TextCtrl")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
+
+    CHAINING_TEST(TextCtrlTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_TextTests.cpp
+++ b/tests/wxUI_TextTests.cpp
@@ -21,26 +21,40 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "wxUI_TestControlCommon.h"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/Text.h>
 
 #include <wx/wx.h>
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Text;
+
+struct TextTestPolicy {
+    using TypeUnderTest = TypeUnderTest;
+    static auto createUUT() { return TypeUnderTest {}; }
+    static auto testStyle() { return wxST_ELLIPSIZE_MIDDLE; }
+    static auto testPosition() { return wxPoint { 1, 2 }; }
+    static auto testSize() { return wxSize { 10, 12 }; }
+    static auto expectedStyle() { return testStyle(); }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
+};
+static auto createUUT() { return TextTestPolicy::createUUT(); }
+
 TEST_CASE("Text")
 {
     SECTION("noargs.1")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        TypeUnderTest uut {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
     }
     SECTION("noargs")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {};
+        auto uut = createUUT();
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetLabel().empty());
     }
@@ -108,7 +122,7 @@ TEST_CASE("Text")
     SECTION("style")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withStyle(wxST_ELLIPSIZE_MIDDLE);
+        auto uut = createUUT().withStyle(wxST_ELLIPSIZE_MIDDLE);
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetWindowStyle() == wxST_ELLIPSIZE_MIDDLE);
     }
@@ -116,7 +130,7 @@ TEST_CASE("Text")
     SECTION("pos")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withPosition({ 1, 2 });
+        auto uut = createUUT().withPosition({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetPosition() == wxPoint { 1, 2 });
     }
@@ -124,9 +138,29 @@ TEST_CASE("Text")
     SECTION("size")
     {
         wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = TypeUnderTest {}.withSize({ 1, 2 });
+        auto uut = createUUT().withSize({ 1, 2 });
         auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
         CHECK(window->GetSize() == wxSize { 1, 2 });
     }
+
+    SECTION("proxy.bind")
+    {
+        wxFrame frame { nullptr, wxID_ANY, "" };
+        auto proxy = TypeUnderTest::Proxy {};
+        auto uut = proxy.bind(TypeUnderTest { "label1" }.withSize({ 1, 2 }));
+        uut.create(&frame);
+        CHECK(proxy->get() == "label1");
+        //        CHECK(static_cast<std::string>(proxy) == "label1");
+        //        CHECK("label1" == static_cast<std::string>(proxy));
+        //        CHECK(static_cast<std::string>(proxy) == "label1");
+        proxy->set("label2");
+        CHECK(proxy->get() == "label2");
+        *proxy = "label3";
+        CHECK(proxy->get() == "label3");
+        std::string result2 = *proxy;
+        CHECK(result2 == "label3");
+    }
+
+    CHAINING_TEST(TextTestPolicy)
 }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)


### PR DESCRIPTION
Utilizing a class specifically for proxy objects.  They are ways to allow access to the control and value within it.

Adding a specific class for getter setter object.  Make sure to add tests specificially for it.  It supports default operators including streaming.

Updating documentation to clarify naming convention.

Adding proxy to example.