### PR TITLE
Minor tweaks and adjustments to build setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .vscode
 .DS_Store
 
+CMakeUserPresets.json

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -10,7 +10,9 @@ cmake_minimum_required(VERSION 3.23)
 include(FetchContent)
 
 if (WXUI_WITH_TESTS OR WXUI_WITH_EXAMPLES)
-  # Have wxWidgets build as static libraries
+  find_package(wxWidgets CONFIG)
+  if(NOT ${wxWidgets_FOUND})
+    # Have wxWidgets build as static libraries
     # FetchContent is used to download the wxWidgets library
     # Have wxWidgets build as static libraries
     set(wxBUILD_SHARED OFF)
@@ -23,6 +25,7 @@ if (WXUI_WITH_TESTS OR WXUI_WITH_EXAMPLES)
       GIT_TAG 8aef5f40b93958719771331ca03866b7b6fff6bf # v3.2.8
     )
     FetchContent_MakeAvailable(wxWidgets)
+  endif()
 endif()
 
 

--- a/examples/HelloWorld/HelloWorld.cpp
+++ b/examples/HelloWorld/HelloWorld.cpp
@@ -28,6 +28,7 @@ SOFTWARE.
 // snippet Example headers to include
 #include <numeric>
 #include <wx/wx.h>
+#include <wx/app.h>
 #include <wxUI/wxUI.hpp>
 // endsnippet Example
 

--- a/examples/HelloWorld/HelloWorld.cpp
+++ b/examples/HelloWorld/HelloWorld.cpp
@@ -27,8 +27,8 @@ SOFTWARE.
 #include "ExtendedExample.hpp"
 // snippet Example headers to include
 #include <numeric>
-#include <wx/wx.h>
 #include <wx/app.h>
+#include <wx/wx.h>
 #include <wxUI/wxUI.hpp>
 // endsnippet Example
 
@@ -198,8 +198,8 @@ HelloWorldFrame::HelloWorldFrame()
 // snippet withwxWidgets : How you build with wxWidgets
 ExampleDialogWidgets::ExampleDialogWidgets(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, "ExampleDialogWidgets",
-        wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+          wxDefaultPosition, wxDefaultSize,
+          wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     // Create the controls.
     auto* text = new wxStaticText(this, wxID_ANY, "Example of Text in wxWidgets");
@@ -306,8 +306,8 @@ ExampleDialogWidgets::ExampleDialogWidgets(wxWindow* parent)
 // snippet withwxUI Dialog example
 ExampleDialog::ExampleDialog(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, "ExampleDialog",
-        wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+          wxDefaultPosition, wxDefaultSize,
+          wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     using namespace wxUI;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 3.23)
 
-FetchContent_Declare(
-  Catch2
-  GIT_REPOSITORY https://github.com/catchorg/Catch2
-  GIT_TAG        2b60af89e23d28eefc081bc930831ee9d45ea58b # v3.8.1
-)
-FetchContent_MakeAvailable(Catch2)
+find_package(Catch2 CONFIG)
+if(NOT ${Catch2_FOUND})
+  FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2
+    GIT_TAG        2b60af89e23d28eefc081bc930831ee9d45ea58b # v3.8.1
+  )
+  FetchContent_MakeAvailable(Catch2)
+endif()
 
 add_executable(wxUI_Tests
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_BitmapTests.cpp


### PR DESCRIPTION
## Changes
- Add `CMakeUserPresets.json` to the `.gitignore` (See https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html for more info)
- Use `find_package()` for dependencies before reverting to `FetchContent`. In certain cases it might be more desirable to use packages locally instead of pulling them and building them along with the project
- Addressed a small `clang-tidy` warning in the example. 