### PR TITLE
Issue #219: We should have customization points for controllers to al…

### DIFF
--- a/.github/workflows/ci_automation.yml
+++ b/.github/workflows/ci_automation.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run clang-format style check for C/C++/Protobuf programs.
-      uses: jidicula/clang-format-action@v4.8.0
+      uses: jidicula/clang-format-action@v4.15.0
       with:
-        clang-format-version: '13'
+        clang-format-version: '14'
         check-path: 'src'
         fallback-style: 'Mozilla' # optional
 

--- a/LATEST_RELEASE_NOTES.md
+++ b/LATEST_RELEASE_NOTES.md
@@ -6,4 +6,5 @@ Other changes:
 
 * [#214](../../issues/214) There should probably be a way to check if a proxy is valid
 * [#217](../../issues/217) Switch from inheritance to composition
+* [#219](../../issues/219) We should have customization points for controllers to allow for testability
 

--- a/include/wxUI/Bitmap.hpp
+++ b/include/wxUI/Bitmap.hpp
@@ -52,10 +52,11 @@ private:
     details::WidgetDetails<Bitmap, wxStaticBitmap> details_;
     wxBitmap bitmap_;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&bitmap = bitmap_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            return new underlying_t(parent, id, bitmap, pos, size, style);
+        return [&bitmap = bitmap_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            return customizations::ParentCreate<underlying_t>(parent, id, bitmap, pos, size, style);
         };
     }
 

--- a/include/wxUI/BitmapButton.hpp
+++ b/include/wxUI/BitmapButton.hpp
@@ -79,12 +79,14 @@ private:
     wxBitmap bitmap_;
     bool isDefault_ = false;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&bitmap = bitmap_, isDefault = isDefault_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            auto* widget = new underlying_t(parent, id, bitmap, pos, size, style);
+        return [&bitmap = bitmap_, isDefault = isDefault_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, bitmap, pos, size, style);
             if (isDefault) {
-                widget->SetDefault();
+                using ::wxUI::customizations::ControllerSetDefault;
+                ControllerSetDefault(widget);
             }
             return widget;
         };

--- a/include/wxUI/BitmapComboBox.hpp
+++ b/include/wxUI/BitmapComboBox.hpp
@@ -127,16 +127,20 @@ private:
     std::vector<wxBitmap> bitmaps_;
     int selection_ = 0;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&choices = choices_, &bitmaps = bitmaps_, selection = selection_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
+        return [&choices = choices_, &bitmaps = bitmaps_, selection = selection_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
             auto&& first = (choices.size() > 0) ? wxString(choices.at(0)) : wxString(wxEmptyString);
-            auto* widget = new underlying_t(parent, id, first, pos, size, static_cast<int>(choices.size()), choices.data(), style);
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, first, pos, size, static_cast<int>(choices.size()), choices.data(), style);
+
             for (auto i = 0lu; i < bitmaps.size(); ++i) {
-                widget->SetItemBitmap(i, bitmaps[i]);
+                using ::wxUI::customizations::ControllerSetItemBitmap;
+                ControllerSetItemBitmap(widget, i, bitmaps[i]);
             }
             if (!choices.empty()) {
-                widget->SetSelection(selection);
+                using ::wxUI::customizations::ControllerSetSelection;
+                ControllerSetSelection(widget, selection);
             }
             return widget;
         };

--- a/include/wxUI/BitmapToggleButton.hpp
+++ b/include/wxUI/BitmapToggleButton.hpp
@@ -79,12 +79,14 @@ private:
     wxBitmap bitmap_;
     std::optional<wxBitmap> bitmapPressed_;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&bitmap = bitmap_, &bitmapPressed = bitmapPressed_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            auto* widget = new underlying_t(parent, id, bitmap, pos, size, style);
+        return [&bitmap = bitmap_, &bitmapPressed = bitmapPressed_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, bitmap, pos, size, style);
             if (bitmapPressed) {
-                widget->SetBitmapPressed(*bitmapPressed);
+                using ::wxUI::customizations::ControllerSetBitmapPressed;
+                ControllerSetBitmapPressed(widget, *bitmapPressed);
             }
             return widget;
         };

--- a/include/wxUI/Button.hpp
+++ b/include/wxUI/Button.hpp
@@ -79,12 +79,14 @@ private:
     std::string text_;
     bool isDefault_ = false;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&text = text_, isDefault = isDefault_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            auto* widget = new underlying_t(parent, id, text, pos, size, style);
+        return [&text = text_, isDefault = isDefault_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, text, pos, size, style);
             if (isDefault) {
-                widget->SetDefault();
+                using ::wxUI::customizations::ControllerSetDefault;
+                ControllerSetDefault(widget);
             }
             return widget;
         };

--- a/include/wxUI/CheckBox.hpp
+++ b/include/wxUI/CheckBox.hpp
@@ -90,11 +90,13 @@ private:
     std::string text_;
     bool value_ = false;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&text = text_, value = value_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            auto* widget = new underlying_t(parent, id, text, pos, size, style);
-            widget->SetValue(value);
+        return [&text = text_, value = value_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, text, pos, size, style);
+            using ::wxUI::customizations::ControllerSetValue;
+            ControllerSetValue(widget, value);
             return widget;
         };
     }

--- a/include/wxUI/Choice.hpp
+++ b/include/wxUI/Choice.hpp
@@ -101,11 +101,13 @@ private:
     std::vector<wxString> choices_ {};
     int selection_ {};
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&choices = choices_, selection = selection_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            auto* widget = new underlying_t(parent, id, pos, size, static_cast<int>(choices.size()), choices.data(), style);
-            widget->SetSelection(selection);
+        return [&choices = choices_, selection = selection_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, pos, size, static_cast<int>(choices.size()), choices.data(), style);
+            using ::wxUI::customizations::ControllerSetSelection;
+            ControllerSetSelection(widget, selection);
             return widget;
         };
     }

--- a/include/wxUI/ComboBox.hpp
+++ b/include/wxUI/ComboBox.hpp
@@ -103,13 +103,15 @@ private:
     std::vector<wxString> choices_;
     int selection_ = 0;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&choices = choices_, selection = selection_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
+        return [&choices = choices_, selection = selection_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
             auto&& first = (choices.size() > 0) ? wxString(choices.at(0)) : wxString(wxEmptyString);
-            auto* widget = new underlying_t(parent, id, first, pos, size, static_cast<int>(choices.size()), choices.data(), style);
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, first, pos, size, static_cast<int>(choices.size()), choices.data(), style);
             if (!choices.empty()) {
-                widget->SetSelection(selection);
+                using ::wxUI::customizations::ControllerSetSelection;
+                ControllerSetSelection(widget, selection);
             }
             return widget;
         };

--- a/include/wxUI/Customizations.hpp
+++ b/include/wxUI/Customizations.hpp
@@ -1,0 +1,204 @@
+/*
+MIT License
+
+Copyright (c) 2022-2025 Richard Powell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#pragma once
+
+namespace wxUI::customizations {
+
+template <typename>
+inline constexpr bool always_false_v = false;
+
+// Customization points for creating underlying widgets via different
+// "parents". By default this will construct the real wxWidgets object
+// when the parent is a wxWindow (or derived). Tests can provide their own
+// specializations of ParentCreateImpl in the wxUI::details namespace to
+// capture calls without needing an actual wxWindow.
+template <typename Underlying, typename Parent>
+struct ParentCreateImpl {
+    template <typename... Args>
+    static auto create(Parent* parent, Args&&... args) -> Underlying*
+    {
+        if constexpr (std::is_convertible_v<Parent*, wxWindow*>) {
+            return new Underlying(parent, std::forward<Args>(args)...);
+        } else {
+            static_assert(std::is_convertible_v<Parent*, wxWindow*>, "ParentCreateImpl must be specialized for non-wx parents");
+            return nullptr; // unreachable
+        }
+    }
+};
+
+// Forwarding convenience function used by controllers. It simply forwards
+// the call to the implementation class above — allowing callers to use a
+// simple function-style API while tests can partially-specialize the
+// class template.
+template <typename Underlying, typename Parent, typename... Args>
+inline auto ParentCreate(Parent* parent, Args&&... args)
+{
+    return ParentCreateImpl<Underlying, Parent>::create(parent, std::forward<Args>(args)...);
+}
+
+//--- Customization points for controllers ---//
+// clang-format off
+
+template <typename Controller>
+inline void ControllerSetDefault(Controller* controller)
+{
+    if constexpr (requires(Controller* w) { w->SetDefault(); }) {
+        controller->SetDefault();
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerSetDefault: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+template <typename Controller>
+inline void ControllerSetFont(Controller* controller, wxFont const& font)
+{
+    if constexpr (requires(Controller* w) { w->SetFont(font); }) {
+        controller->SetFont(font);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerSetFont: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+template <typename Controller>
+inline void ControllerSetEnabled(Controller* controller, bool enabled)
+{
+    if constexpr (requires(Controller* w) { w->Enable(enabled); }) {
+        controller->Enable(enabled);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerSetEnabled: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+template <typename Controller>
+inline void ControllerEnsureVisible(Controller* controller, bool visible)
+{
+    if constexpr (requires(Controller* w) { w->EnsureVisible(visible); }) {
+        controller->EnsureVisible(visible);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerEnsureVisible: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+template <typename Controller>
+inline void ControllerWrap(Controller* controller, bool wrap)
+{
+    if constexpr (requires(Controller* w) { w->Wrap(wrap); }) {
+        controller->Wrap(wrap);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerWrap: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+template <typename Controller>
+inline void ControllerBindEvent(Controller* controller, details::BindInfo const& boundedFunction)
+{
+    if constexpr (std::is_convertible_v<Controller*, wxWindow*>) {
+        boundedFunction.bindTo(controller);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerBindEvent: Provide a customization in namespace wxUI::customizations..");
+    }
+}
+
+template <typename Controller, typename Proxy>
+inline void ControllerBindProxy(Controller* controller, Proxy& proxyHandle)
+{
+    if constexpr (requires(Proxy proxy, Controller* c) { proxy.setUnderlying(c); }) {
+        proxyHandle.setUnderlying(controller);
+    } else {
+        static_assert(always_false_v<Proxy>, "ControllerBindProxy: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+template <typename Controller>
+inline void ControllerSetValue(Controller* controller, bool value)
+{
+    if constexpr (requires(Controller* w) { w->SetValue(value); }) {
+        controller->SetValue(value);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerSetValue: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+template <typename Controller>
+inline void ControllerSetSelection(Controller* controller, int selection)
+{
+    if constexpr (requires(Controller* w) { w->SetSelection(selection); }) {
+        controller->SetSelection(selection);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerSetSelection: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+template <typename Controller, typename Bitmap>
+inline void ControllerSetItemBitmap(Controller* controller, unsigned int n, Bitmap const& bitmap)
+{
+    if constexpr (requires(Controller* w) { w->SetItemBitmap(n, bitmap); }) {
+        controller->SetItemBitmap(n, bitmap);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerSetItemBitmap: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+template <typename Controller, typename Bitmap>
+inline void ControllerSetBitmapPressed(Controller* controller, Bitmap const& bitmap)
+{
+    if constexpr (requires(Controller* w) { w->SetBitmapPressed(bitmap); }) {
+        controller->SetBitmapPressed(bitmap);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerSetBitmapPressed: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+template <typename Controller, typename W1, typename W2>
+inline void ControllerSplitHorizontal(Controller* controller, W1* window1, W2* window2)
+{
+    if constexpr (requires(Controller* w) { w->SplitHorizontally(window1, window2); }) {
+        controller->SplitHorizontally(window1, window2);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerSplitHorizontal: Provide a customization in namespace wxUI::customizations..");
+    }
+}
+
+template <typename Controller, typename W1, typename W2>
+inline void ControllerSplitVertical(Controller* controller, W1* window1, W2* window2)
+{
+    if constexpr (requires(Controller* w) { w->SplitVertically(window1, window2); }) {
+        controller->SplitVertically(window1, window2);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerSplitVertically: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+template <typename Controller>
+inline void ControllerSetSashGravity(Controller* controller, double gravity)
+{
+    if constexpr (requires(Controller* w) { w->SetSashGravity(gravity); }) {
+        controller->SetSashGravity(gravity);
+    } else {
+        static_assert(always_false_v<Controller>, "ControllerSetSashGravity: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+// clang-format on
+
+}

--- a/include/wxUI/Gauge.hpp
+++ b/include/wxUI/Gauge.hpp
@@ -82,10 +82,11 @@ private:
     details::WidgetDetails<Gauge, wxGauge> details_;
     int range_;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [range = range_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            return new underlying_t(parent, id, range, pos, size, style);
+        return [range = range_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            return customizations::ParentCreate<underlying_t>(parent, id, range, pos, size, style);
         };
     }
 

--- a/include/wxUI/HelperMacros.hpp
+++ b/include/wxUI/HelperMacros.hpp
@@ -32,15 +32,15 @@ SOFTWARE.
 // clang-format off
 
 #if !defined(WXUI_RULE_OF_SIX_BOILERPLATE)
-#define WXUI_RULE_OF_SIX_BOILERPLATE(WIDGET)               \
-    WIDGET(WIDGET const&) = default;                  \
-    WIDGET(WIDGET&&) noexcept = default;              \
-    auto operator=(WIDGET const&)->WIDGET& = default; \
+#define WXUI_RULE_OF_SIX_BOILERPLATE(WIDGET)            \
+    WIDGET(WIDGET const&) = default;                    \
+    WIDGET(WIDGET&&) noexcept = default;                \
+    auto operator=(WIDGET const&) -> WIDGET& = default; \
     auto operator=(WIDGET&&) noexcept -> WIDGET& = default;
 #endif
 
 #if !defined(WXUI_WIDGET_STATIC_ASSERT_BOILERPLATE)
-#define WXUI_WIDGET_STATIC_ASSERT_BOILERPLATE(WIDGET)                 \
+#define WXUI_WIDGET_STATIC_ASSERT_BOILERPLATE(WIDGET)            \
     static_assert(details::CreateAndAddable<WIDGET>);            \
     static_assert(details::Createable<WIDGET>);                  \
     static_assert(std::is_nothrow_move_constructible_v<WIDGET>); \
@@ -48,14 +48,16 @@ SOFTWARE.
 #endif
 
 #if !defined(WXUI_WIDGET_CREATE_BOILERPLATE)
-#define WXUI_WIDGET_CREATE_BOILERPLATE                                                                         \
-    auto create(wxWindow* parent) -> underlying_t*                                                        \
+#define WXUI_WIDGET_CREATE_BOILERPLATE                                                                    \
+    template <typename Provider = wxWindow>                                                               \
+    auto create(Provider* parent)                                                                         \
     {                                                                                                     \
-        return details_.create(createImpl(), parent);                                                     \
+        return details_.create(this->template createImpl<Provider>(), parent);                            \
     }                                                                                                     \
-    auto createAndAdd(wxWindow* parent, wxSizer* sizer, wxSizerFlags const& parentFlags) -> underlying_t* \
+    template <typename Provider = wxWindow>                                                               \
+    auto createAndAdd(Provider* parent, wxSizer* sizer, wxSizerFlags const& parentFlags) -> underlying_t* \
     {                                                                                                     \
-        return details_.createAndAdd(createImpl(), parent, sizer, parentFlags);                           \
+        return details_.createAndAdd(this->template createImpl<Provider>(), parent, sizer, parentFlags);  \
     }
 #endif
 

--- a/include/wxUI/Hyperlink.hpp
+++ b/include/wxUI/Hyperlink.hpp
@@ -55,10 +55,11 @@ private:
     std::string text_;
     std::string url_;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&text = text_, &url = url_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            return new underlying_t(parent, id, text, url, pos, size, style);
+        return [&text = text_, &url = url_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            return customizations::ParentCreate<underlying_t>(parent, id, text, url, pos, size, style);
         };
     }
 

--- a/include/wxUI/Line.hpp
+++ b/include/wxUI/Line.hpp
@@ -45,10 +45,11 @@ struct Line {
 private:
     details::WidgetDetails<Line, wxStaticLine> details_;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            return new underlying_t(parent, id, pos, size, style);
+        return [](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            return customizations::ParentCreate<underlying_t>(parent, id, pos, size, style);
         };
     }
 

--- a/include/wxUI/ListBox.hpp
+++ b/include/wxUI/ListBox.hpp
@@ -174,15 +174,18 @@ private:
     std::vector<int> selection_;
     std::optional<int> ensureVisible_ {};
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&choices = choices_, &selection = selection_, &ensureVisible = ensureVisible_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            auto* widget = new underlying_t(parent, id, pos, size, static_cast<int>(choices.size()), choices.data(), style);
+        return [&choices = choices_, &selection = selection_, &ensureVisible = ensureVisible_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, pos, size, static_cast<int>(choices.size()), choices.data(), style);
             for (auto&& selection : selection) {
-                widget->SetSelection(selection);
+                using ::wxUI::customizations::ControllerSetSelection;
+                ControllerSetSelection(widget, selection);
             }
             if (ensureVisible) {
-                widget->EnsureVisible(*ensureVisible);
+                using ::wxUI::customizations::ControllerEnsureVisible;
+                ControllerEnsureVisible(widget, *ensureVisible);
             }
             return widget;
         };

--- a/include/wxUI/RadioBox.hpp
+++ b/include/wxUI/RadioBox.hpp
@@ -163,11 +163,13 @@ private:
     int majorDim_ {};
     int selection_ {};
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&text = text_, &choices = choices_, majorDim = majorDim_, selection = selection_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            auto* widget = new underlying_t(parent, id, text, pos, size, static_cast<int>(choices.size()), choices.data(), majorDim, style);
-            widget->SetSelection(selection);
+        return [&text = text_, &choices = choices_, majorDim = majorDim_, selection = selection_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, text, pos, size, static_cast<int>(choices.size()), choices.data(), majorDim, style);
+            using ::wxUI::customizations::ControllerSetSelection;
+            ControllerSetSelection(widget, selection);
             return widget;
         };
     }

--- a/include/wxUI/Slider.hpp
+++ b/include/wxUI/Slider.hpp
@@ -40,9 +40,25 @@ struct Slider {
     {
     }
 
+    // Convenience overload to allow brace-init like Slider{{10,20}, 12}
+    explicit Slider(std::pair<int, int> range, std::optional<int> initial = std::nullopt)
+        : details_(wxID_ANY)
+        , range_(range)
+        , initial_(initial)
+    {
+    }
+
     explicit Slider(wxWindowID identity, std::optional<std::pair<int, int>> range = std::nullopt, std::optional<int> initial = std::nullopt)
         : details_(identity)
         , range_(std::move(range))
+        , initial_(initial)
+    {
+    }
+
+    // Convenience overload with explicit identity
+    explicit Slider(wxWindowID identity, std::pair<int, int> range, std::optional<int> initial = std::nullopt)
+        : details_(identity)
+        , range_(range)
         , initial_(initial)
     {
     }
@@ -79,14 +95,14 @@ private:
     std::optional<std::pair<int, int>> range_;
     std::optional<int> initial_;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&range = range_, &initial = initial_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
+        return [&range = range_, &initial = initial_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
             auto min = range ? range->first : 0;
             auto max = range ? range->second : 100;
             auto initvalue = initial.value_or(min);
-            auto* widget = new underlying_t(parent, id, initvalue, min, max, pos, size, style);
-            return widget;
+            return customizations::ParentCreate<underlying_t>(parent, id, initvalue, min, max, pos, size, style);
         };
     }
 

--- a/include/wxUI/SpinCtrl.hpp
+++ b/include/wxUI/SpinCtrl.hpp
@@ -40,9 +40,25 @@ struct SpinCtrl {
     {
     }
 
+    // Convenience overload to allow brace-init like SpinCtrl{{0,10}, 3}
+    explicit SpinCtrl(std::pair<int, int> range, std::optional<int> initial = std::nullopt)
+        : details_(wxID_ANY)
+        , range_(range)
+        , initial_(initial)
+    {
+    }
+
     explicit SpinCtrl(wxWindowID identity, std::optional<std::pair<int, int>> range = std::nullopt, std::optional<int> initial = std::nullopt)
         : details_(identity)
         , range_(std::move(range))
+        , initial_(initial)
+    {
+    }
+
+    // Convenience overload with explicit identity
+    explicit SpinCtrl(wxWindowID identity, std::pair<int, int> range, std::optional<int> initial = std::nullopt)
+        : details_(identity)
+        , range_(range)
         , initial_(initial)
     {
     }
@@ -79,14 +95,14 @@ private:
     std::optional<std::pair<int, int>> range_;
     std::optional<int> initial_;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&range = range_, &initial = initial_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
+        return [&range = range_, &initial = initial_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
             auto min = range ? range->first : 0;
             auto max = range ? range->second : 100;
             auto initvalue = initial.value_or(min);
-            auto* widget = new underlying_t(parent, id, wxEmptyString, pos, size, style, min, max, initvalue);
-            return widget;
+            return customizations::ParentCreate<underlying_t>(parent, id, wxEmptyString, pos, size, style, min, max, initvalue);
         };
     }
 

--- a/include/wxUI/Splitter.hpp
+++ b/include/wxUI/Splitter.hpp
@@ -76,13 +76,16 @@ private:
     std::pair<W1, W2> widgets_;
     std::optional<double> stashGravity_ {};
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&widgets = widgets_, &stashGravity = stashGravity_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            auto* widget = new underlying_t(parent, id, pos, size, style);
-            widget->SplitHorizontally(std::get<0>(widgets).create(widget), std::get<1>(widgets).create(widget));
+        return [&widgets = widgets_, &stashGravity = stashGravity_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, pos, size, style);
+            using ::wxUI::customizations::ControllerSplitHorizontal;
+            ControllerSplitHorizontal(widget, std::get<0>(widgets).create(widget), std::get<1>(widgets).create(widget));
             if (stashGravity) {
-                widget->SetSashGravity(*stashGravity);
+                using ::wxUI::customizations::ControllerSetSashGravity;
+                ControllerSetSashGravity(widget, *stashGravity);
             }
             return widget;
         };
@@ -132,13 +135,16 @@ private:
     std::pair<W1, W2> widgets_;
     std::optional<double> stashGravity_ {};
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&widgets = widgets_, &stashGravity = stashGravity_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            auto* widget = new underlying_t(parent, id, pos, size, style);
-            widget->SplitVertically(std::get<0>(widgets).create(widget), std::get<1>(widgets).create(widget));
+        return [&widgets = widgets_, &stashGravity = stashGravity_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, pos, size, style);
+            using ::wxUI::customizations::ControllerSplitVertical;
+            ControllerSplitVertical(widget, std::get<0>(widgets).create(widget), std::get<1>(widgets).create(widget));
             if (stashGravity) {
-                widget->SetSashGravity(*stashGravity);
+                using ::wxUI::customizations::ControllerSetSashGravity;
+                ControllerSetSashGravity(widget, *stashGravity);
             }
             return widget;
         };

--- a/include/wxUI/Text.hpp
+++ b/include/wxUI/Text.hpp
@@ -76,12 +76,15 @@ private:
     std::string text_;
     std::optional<int> wrap_;
 
+    // Templated createImpl to support test Providers
+    template <typename Parent>
     auto createImpl()
     {
-        return [&text = text_, &wrap = wrap_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            auto* widget = new underlying_t(parent, id, text, pos, size, style);
+        return [&text = text_, &wrap = wrap_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            auto* widget = customizations::ParentCreate<underlying_t>(parent, id, text, pos, size, style);
             if (wrap) {
-                widget->Wrap(*wrap);
+                using ::wxUI::customizations::ControllerWrap;
+                ControllerWrap(widget, *wrap);
             }
             return widget;
         };

--- a/include/wxUI/TextCtrl.hpp
+++ b/include/wxUI/TextCtrl.hpp
@@ -77,10 +77,11 @@ private:
     details::WidgetDetails<TextCtrl, wxTextCtrl> details_;
     std::string text_;
 
+    template <typename Parent>
     auto createImpl()
     {
-        return [&text = text_](wxWindow* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) -> underlying_t* {
-            return new underlying_t(parent, id, text, pos, size, style);
+        return [&text = text_](Parent* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style) {
+            return customizations::ParentCreate<underlying_t>(parent, id, text, pos, size, style);
         };
     }
 

--- a/tests/TestCustomizations.hpp
+++ b/tests/TestCustomizations.hpp
@@ -1,0 +1,544 @@
+/*
+MIT License
+
+Copyright (c) 2022-2025 Richard Powell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#pragma once
+
+#include <format>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <vector>
+#include <wx/bmpbuttn.h>
+#include <wx/bmpcbox.h>
+#include <wx/checkbox.h>
+#include <wx/choice.h>
+#include <wx/combobox.h>
+#include <wx/gauge.h>
+#include <wx/hyperlink.h>
+#include <wx/listbox.h>
+#include <wx/radiobox.h>
+#include <wx/slider.h>
+#include <wx/spinctrl.h>
+#include <wx/splitter.h>
+#include <wx/statbmp.h>
+#include <wx/statline.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+#include <wx/tglbtn.h>
+
+// Forward declarations to avoid including Widget.hpp here. We want the
+// test-provider customization overloads to be visible to translation
+// units before Widget.hpp is processed so qualified calls in that header
+// can find these overloads. Only a couple of types are needed here.
+namespace wxUI::details {
+struct BindInfo;
+template <typename T>
+struct WidgetProxy;
+}
+
+// helpful formatters
+template <>
+struct std::formatter<wxSize, char> {
+    constexpr auto parse(std::format_parse_context& ctx) { return ctx.begin(); }
+    auto format(wxSize const& size, std::format_context& ctx) const
+    {
+        return std::format_to(ctx.out(), "({},{})", size.GetWidth(), size.GetHeight());
+    }
+};
+template <>
+struct std::formatter<wxPoint, char> {
+    constexpr auto parse(std::format_parse_context& ctx) { return ctx.begin(); }
+    auto format(wxPoint const& pos, std::format_context& ctx) const
+    {
+        return std::format_to(ctx.out(), "({},{})", pos.x, pos.y);
+    }
+};
+template <>
+struct std::formatter<wxBitmap, char> {
+    constexpr auto parse(std::format_parse_context& ctx) { return ctx.begin(); }
+    auto format(wxBitmap const& bitmap, std::format_context& ctx) const
+    {
+        return std::format_to(ctx.out(), "{}", bitmap.GetSize());
+    }
+};
+
+namespace wxUITests {
+
+struct TestProvider {
+    std::string type;
+    int id {};
+    wxPoint pos {};
+    wxSize size {};
+    int64_t style {};
+    std::optional<std::string> text {};
+    std::optional<std::string> text2 {};
+    std::optional<wxBitmap> bitmap {};
+    std::optional<std::vector<std::string>> choices {};
+    std::optional<int> value {};
+    std::optional<std::pair<int, int>> range {};
+    std::optional<int> majorDim {};
+
+    std::vector<std::string> log {};
+    std::list<TestProvider> providers {};
+
+    auto add(TestProvider controller) -> TestProvider*;
+    auto dump() const -> std::vector<std::string>;
+};
+
+}
+
+template <>
+struct std::formatter<wxUITests::TestProvider, char> {
+    // No format specifications supported.
+    constexpr auto parse(std::format_parse_context& ctx) { return ctx.begin(); }
+
+    auto format(wxUITests::TestProvider const& c, std::format_context& ctx) const
+    {
+        std::format_to(
+            ctx.out(), "{}[id={}, pos={}, size={}, style={}", c.type, c.id, c.pos, c.size, c.style);
+        if (c.text.has_value()) {
+            std::format_to(ctx.out(), ", text=\"{}\"", *c.text);
+        }
+        if (c.text2.has_value()) {
+            std::format_to(ctx.out(), ", text2=\"{}\"", *c.text2);
+        }
+        if (c.bitmap.has_value()) {
+            std::format_to(ctx.out(), ", bitmap={}", *c.bitmap);
+        }
+        if (c.choices.has_value()) {
+            std::format_to(ctx.out(), ", choices=(");
+            for (auto& i : *c.choices) {
+                std::format_to(ctx.out(), "\"{}\",", i);
+            }
+            std::format_to(ctx.out(), ")");
+        }
+        if (c.value.has_value()) {
+            std::format_to(ctx.out(), ", value={}", *c.value);
+        }
+        if (c.range.has_value()) {
+            std::format_to(ctx.out(), ", range=[{},{}]", c.range->first, c.range->second);
+        }
+        if (c.majorDim.has_value()) {
+            std::format_to(ctx.out(), ", majorDim={}", *c.majorDim);
+        }
+        return std::format_to(ctx.out(), "]");
+    }
+};
+
+namespace wxUITests {
+inline auto TestProvider::add(TestProvider controller) -> TestProvider*
+{
+    providers.push_back(controller);
+    log.push_back(std::format("Create:{}", controller));
+    return &providers.back();
+}
+inline auto TestProvider::dump() const -> std::vector<std::string>
+{
+    auto result = std::vector<std::string> {};
+    for (auto controller : providers) {
+        result.push_back(std::format("controller:{}", controller));
+        result.insert(result.end(), controller.log.begin(), controller.log.end());
+    }
+    return result;
+}
+
+}
+namespace wxUI::customizations {
+// Forward-declare the primary template so we can provide partial
+// specializations in this header even if the primary template is
+// declared later (e.g., in include/wxUI/Customizations.hpp).
+template <typename Underlying, typename Parent>
+struct ParentCreateImpl;
+
+template <>
+struct ParentCreateImpl<wxStaticBitmap, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, wxBitmap bitmap, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxStaticBitmap",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .bitmap = bitmap,
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxBitmapButton, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, wxBitmap bitmap, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxBitmapButton",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .bitmap = bitmap,
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxBitmapComboBox, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, std::string first, wxPoint pos, wxSize size, int n, const wxString* choices, int64_t style)
+    {
+        auto tchoices = std::vector<std::string> {};
+        for (auto i = 0; i < n; ++i) {
+            tchoices.push_back(choices[i]);
+        }
+        return parent->add({
+            .type = "wxBitmapComboBox",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .text = std::move(first),
+            .choices = std::move(tchoices),
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxBitmapToggleButton, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, wxBitmap bitmap, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxBitmapToggleButton",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .bitmap = bitmap,
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxButton, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, std::string text, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxButton",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .text = std::move(text),
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxCheckBox, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, std::string text, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxCheckBox",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .text = std::move(text),
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxChoice, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, wxPoint pos, wxSize size, int n, const wxString* choices, int64_t style)
+    {
+        auto tchoices = std::vector<std::string> {};
+        for (auto i = 0; i < n; ++i) {
+            tchoices.push_back(choices[i]);
+        }
+        return parent->add({
+            .type = "wxChoice",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .choices = std::move(tchoices),
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxComboBox, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, std::string first, wxPoint pos, wxSize size, int n, const wxString* choices, int64_t style)
+    {
+        auto tchoices = std::vector<std::string> {};
+        for (auto i = 0; i < n; ++i) {
+            tchoices.push_back(choices[i]);
+        }
+        return parent->add({
+            .type = "wxComboBox",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .text = std::move(first),
+            .choices = std::move(tchoices),
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxGauge, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, int value, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxGauge",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .value = value,
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxHyperlinkCtrl, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, std::string text, std::string text2, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxHyperlinkCtrl",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .text = std::move(text),
+            .text2 = std::move(text2),
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxStaticLine, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxStaticLine",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxListBox, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, wxPoint pos, wxSize size, int n, const wxString* choices, int64_t style)
+    {
+        auto tchoices = std::vector<std::string> {};
+        for (auto i = 0; i < n; ++i) {
+            tchoices.push_back(choices[i]);
+        }
+        return parent->add({
+            .type = "wxListBox",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .choices = std::move(tchoices),
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxRadioBox, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, std::string text, wxPoint pos, wxSize size, int n, const wxString* choices, int majorDim, int64_t style)
+    {
+        auto tchoices = std::vector<std::string> {};
+        for (auto i = 0; i < n; ++i) {
+            tchoices.push_back(choices[i]);
+        }
+        return parent->add({
+            .type = "wxRadioBox",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .text = std::move(text),
+            .choices = std::move(tchoices),
+            .majorDim = majorDim,
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxSlider, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, int value, int min, int max, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxSlider",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .value = value,
+            .range = std::pair<int, int> { min, max },
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxSpinCtrl, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, [[maybe_unused]] wxString const& text, wxPoint pos, wxSize size, int64_t style, int min, int max, int value)
+    {
+        return parent->add({
+            .type = "wxSpinCtrl",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .value = value,
+            .range = std::pair<int, int> { min, max },
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxTextCtrl, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, std::string text, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxTextCtrl",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .text = std::move(text),
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxStaticText, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, std::string text, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxStaticText",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+            .text = std::move(text),
+        });
+    }
+};
+
+template <>
+struct ParentCreateImpl<wxSplitterWindow, wxUITests::TestProvider> {
+    static auto create(wxUITests::TestProvider* parent, wxWindowID id, wxPoint pos, wxSize size, int64_t style)
+    {
+        return parent->add({
+            .type = "wxSplitterWindow",
+            .id = id,
+            .pos = pos,
+            .size = size,
+            .style = style,
+        });
+    }
+};
+
+inline void ControllerSetDefault(wxUITests::TestProvider* controller)
+{
+    controller->log.push_back(std::format("SetDefault:{}", controller->id));
+}
+
+inline void ControllerSetFont(wxUITests::TestProvider* controller, wxFont const& font)
+{
+    controller->log.push_back(std::format("SetFont:{}", font.GetPointSize()));
+}
+
+inline void ControllerSetEnabled(wxUITests::TestProvider* controller, bool enabled)
+{
+    controller->log.push_back(std::format("SetEnabled:{}", enabled ? "true" : "false"));
+}
+
+inline void ControllerBindEvent(wxUITests::TestProvider* controller, [[maybe_unused]] wxUI::details::BindInfo const& boundedFunction)
+{
+    auto count = std::ranges::count_if(controller->log, [](auto const& e) { return e.starts_with("BindEvents:"); });
+    controller->log.push_back(std::format("BindEvents:{}", count + 1));
+}
+
+template <typename Proxy>
+inline void ControllerBindProxy(wxUITests::TestProvider* controller, [[maybe_unused]] Proxy& proxyHandle)
+{
+    auto count = std::ranges::count_if(controller->log, [](auto const& e) { return e.starts_with("BindProxy:"); });
+    controller->log.push_back(std::format("BindProxy:{}", count + 1));
+}
+
+inline void ControllerSetSelection(wxUITests::TestProvider* controller, int selection)
+{
+    controller->log.push_back(std::format("SetSelection:{}", selection));
+}
+
+template <typename Bitmap>
+inline void ControllerSetItemBitmap(wxUITests::TestProvider* controller, unsigned int n, Bitmap const& bitmap)
+{
+    controller->log.push_back(std::format("SetItemBitmap:{}:{}", n, bitmap));
+}
+
+template <typename Bitmap>
+inline void ControllerSetBitmapPressed(wxUITests::TestProvider* controller, Bitmap const& bitmap)
+{
+    controller->log.push_back(std::format("SetBitmapPressed:{}", bitmap));
+}
+
+inline void ControllerSetValue(wxUITests::TestProvider* controller, bool value)
+{
+    controller->log.push_back(std::format("SetValue:{}", value));
+}
+
+inline void ControllerEnsureVisible(wxUITests::TestProvider* controller, bool value)
+{
+    controller->log.push_back(std::format("EnsureVisible:{}", value));
+}
+
+inline void ControllerWrap(wxUITests::TestProvider* controller, bool value)
+{
+    controller->log.push_back(std::format("Wrap:{}", value));
+}
+
+inline void ControllerSplitHorizontal(wxUITests::TestProvider* controller, wxUITests::TestProvider* window1, wxUITests::TestProvider* window2)
+{
+    controller->log.push_back(std::format("SplitHorizontal:{}:{}", *window1, *window2));
+}
+
+inline void ControllerSplitVertical(wxUITests::TestProvider* controller, wxUITests::TestProvider* window1, wxUITests::TestProvider* window2)
+{
+    controller->log.push_back(std::format("SplitVertical:{}:{}", *window1, *window2));
+}
+
+inline void ControllerSetSashGravity(wxUITests::TestProvider* controller, double gravity)
+{
+    controller->log.push_back(std::format("SetSashGravity:{}", gravity));
+}
+
+}

--- a/tests/wxUI_BitmapButtonTests.cpp
+++ b/tests/wxUI_BitmapButtonTests.cpp
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "TestCustomizations.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/BitmapButton.hpp>
 
@@ -30,6 +31,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::BitmapButton;
+using namespace wxUITests;
 
 struct BitmapButtonTestPolicy {
     using TypeUnderTest = wxUI::BitmapButton;
@@ -47,43 +49,57 @@ TEST_CASE("BitmapButton")
 {
     SECTION("bitmap")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, bitmap=(-1,-1)]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.bitmap")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, wxBitmap {} };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, bitmap=(-1,-1)]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("style")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withStyle(wxBU_LEFT);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetWindowStyle() == (wxBU_LEFT | wxBU_EXACTFIT | wxBU_NOTEXT));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapButton[id=-1, pos=(-1,-1), size=(-1,-1), style=64, bitmap=(-1,-1)]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapButton[id=-1, pos=(1,2), size=(-1,-1), style=0, bitmap=(-1,-1)]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapButton[id=-1, pos=(-1,-1), size=(1,2), style=0, bitmap=(-1,-1)]",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(BitmapButtonTestPolicy)

--- a/tests/wxUI_BitmapComboBoxTests.cpp
+++ b/tests/wxUI_BitmapComboBoxTests.cpp
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "TestCustomizations.hpp"
 #include "wxUI_TestControlCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/BitmapComboBox.hpp>
@@ -29,6 +30,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::BitmapComboBox;
+using namespace wxUITests;
 
 struct BitmapComboBoxTestPolicy {
     using TypeUnderTest = wxUI::BitmapComboBox;
@@ -46,89 +48,141 @@ TEST_CASE("BitmapComboBox")
 {
     SECTION("bitmap")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapComboBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=(\"\",\"\",)]",
+                  "SetItemBitmap:0:(-1,-1)",
+                  "SetItemBitmap:1:(-1,-1)",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.bitmap")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, { { std::string {}, wxBitmap {} }, { std::string {}, wxBitmap {} } } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapComboBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=(\"\",\"\",)]",
+                  "SetItemBitmap:0:(-1,-1)",
+                  "SetItemBitmap:1:(-1,-1)",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size.bitmap")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { { { std::string {}, wxBitmap {} }, { std::string {}, wxBitmap {} } } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapComboBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=(\"\",\"\",)]",
+                  "SetItemBitmap:0:(-1,-1)",
+                  "SetItemBitmap:1:(-1,-1)",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size.id.bitmap")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, { { std::string {}, wxBitmap {} }, { std::string {}, wxBitmap {} } } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapComboBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=(\"\",\"\",)]",
+                  "SetItemBitmap:0:(-1,-1)",
+                  "SetItemBitmap:1:(-1,-1)",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("bitmap.ranges")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { std::vector<std::tuple<std::string, wxBitmap>> { { std::string {}, wxBitmap {} }, { std::string {}, wxBitmap {} } } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapComboBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=(\"\",\"\",)]",
+                  "SetItemBitmap:0:(-1,-1)",
+                  "SetItemBitmap:1:(-1,-1)",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.bitmap.ranges")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, std::vector<std::tuple<std::string, wxBitmap>> { { std::string {}, wxBitmap {} }, { std::string {}, wxBitmap {} } } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapComboBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=(\"\",\"\",)]",
+                  "SetItemBitmap:0:(-1,-1)",
+                  "SetItemBitmap:1:(-1,-1)",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapComboBox[id=-1, pos=(1,2), size=(-1,-1), style=0, text=\"\", choices=(\"\",\"\",)]",
+                  "SetItemBitmap:0:(-1,-1)",
+                  "SetItemBitmap:1:(-1,-1)",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapComboBox[id=-1, pos=(-1,-1), size=(1,2), style=0, text=\"\", choices=(\"\",\"\",)]",
+                  "SetItemBitmap:0:(-1,-1)",
+                  "SetItemBitmap:1:(-1,-1)",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("setSelection")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, { { "Hello", wxBitmap {} }, { "Goodbye", wxBitmap {} } } }.withSize({ 1, 2 }).withSelection(1);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(2 == window->GetCount());
-        CHECK(1 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapComboBox[id=10000, pos=(-1,-1), size=(1,2), style=0, text=\"Hello\", choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetItemBitmap:0:(-1,-1)",
+                  "SetItemBitmap:1:(-1,-1)",
+                  "SetSelection:1",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("Empty")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = wxUI::BitmapComboBox { {} };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapComboBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=(\"\",)]",
+                  "SetItemBitmap:0:(-1,-1)",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
     COMMON_TESTS(BitmapComboBoxTestPolicy)
 }

--- a/tests/wxUI_BitmapTests.cpp
+++ b/tests/wxUI_BitmapTests.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Bitmap;
+using namespace wxUITests;
 
 struct BitmapTestPolicy {
     using TypeUnderTest = wxUI::Bitmap;
@@ -46,18 +47,24 @@ TEST_CASE("Bitmap")
 {
     SECTION("bitmap")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window != nullptr);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxStaticBitmap[id=-1, pos=(-1,-1), size=(-1,-1), style=0, bitmap=(-1,-1)]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.bitmap")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, wxBitmap {} };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxStaticBitmap[id=10000, pos=(-1,-1), size=(-1,-1), style=0, bitmap=(-1,-1)]",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(BitmapTestPolicy)

--- a/tests/wxUI_BitmapToggleButtonTests.cpp
+++ b/tests/wxUI_BitmapToggleButtonTests.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::BitmapToggleButton;
+using namespace wxUITests;
 
 struct BitmapToggleButtonTestPolicy {
     using TypeUnderTest = wxUI::BitmapToggleButton;
@@ -46,52 +47,70 @@ TEST_CASE("BitmapToggleButton")
 {
     SECTION("bitmap")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapToggleButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, bitmap=(-1,-1)]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("bitmap.toggle")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { wxBitmap {}, wxBitmap {} };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapToggleButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, bitmap=(-1,-1)]",
+                  "SetBitmapPressed:(-1,-1)",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.bitmap")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, wxBitmap {} };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapToggleButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, bitmap=(-1,-1)]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.bitmap.toggle")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, wxBitmap {}, wxBitmap {} };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapToggleButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, bitmap=(-1,-1)]",
+                  "SetBitmapPressed:(-1,-1)",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapToggleButton[id=-1, pos=(1,2), size=(-1,-1), style=0, bitmap=(-1,-1)]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxBitmapToggleButton[id=-1, pos=(-1,-1), size=(1,2), style=0, bitmap=(-1,-1)]",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(BitmapToggleButtonTestPolicy)

--- a/tests/wxUI_ButtonTests.cpp
+++ b/tests/wxUI_ButtonTests.cpp
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+#include "TestCustomizations.hpp"
 #include "wxUI_TestControlCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/Button.hpp>
@@ -29,6 +30,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Button;
+using namespace wxUITests;
 
 struct ButtonTestPolicy {
     using TypeUnderTest = wxUI::Button;
@@ -46,60 +48,92 @@ TEST_CASE("Button")
 {
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("name")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { "Hello" };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK("Hello" == window->GetLabel());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.name")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, "Hello" };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK("Hello" == window->GetLabel());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("style")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withStyle(wxBU_LEFT);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetWindowStyle() == wxBU_LEFT);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=64, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxButton[id=-1, pos=(1,2), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxButton[id=-1, pos=(-1,-1), size=(1,2), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
+    }
+
+    SECTION("AI Gen")
+    {
+        TestProvider provider;
+        auto uut = wxUI::Button { "Hello" }.withStyle(wxBU_LEFT).withPosition({ 1, 2 }).withSize({ 10, 12 }).setDefault().bind([] {});
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxButton[id=-1, pos=(1,2), size=(10,12), style=64, text=\"Hello\"]",
+                  "SetDefault:-1",
+                  "SetEnabled:true",
+                  "BindEvents:1",
+              });
     }
 
     COMMON_TESTS(ButtonTestPolicy)

--- a/tests/wxUI_CheckBoxTests.cpp
+++ b/tests/wxUI_CheckBoxTests.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::CheckBox;
+using namespace wxUITests;
 
 struct CheckBoxTestPolicy {
     using TypeUnderTest = wxUI::CheckBox;
@@ -46,60 +47,86 @@ TEST_CASE("CheckBox")
 {
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxCheckBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetValue:false",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("name")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { "Hello" };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK("Hello" == window->GetLabel());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxCheckBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+                  "SetValue:false",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxCheckBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetValue:false",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.name")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, "Hello" };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK("Hello" == window->GetLabel());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxCheckBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+                  "SetValue:false",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("style")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withStyle(wxCHK_3STATE);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetWindowStyle() == wxCHK_3STATE);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxCheckBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4096, text=\"\"]",
+                  "SetValue:false",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxCheckBox[id=-1, pos=(1,2), size=(-1,-1), style=0, text=\"\"]",
+                  "SetValue:false",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxCheckBox[id=-1, pos=(-1,-1), size=(1,2), style=0, text=\"\"]",
+                  "SetValue:false",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(CheckBoxTestPolicy)

--- a/tests/wxUI_ChoiceTests.cpp
+++ b/tests/wxUI_ChoiceTests.cpp
@@ -30,6 +30,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Choice;
+using namespace wxUITests;
 
 struct ChoiceTestPolicy {
     using TypeUnderTest = wxUI::Choice;
@@ -47,112 +48,147 @@ TEST_CASE("Choice")
 {
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(0 == window->GetCount());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=()]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("choice")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { "Hello", "Goodbye" };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(0 == window->GetCount());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=10000, pos=(-1,-1), size=(-1,-1), style=0, choices=()]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.choice")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, { "Hello", "Goodbye" } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=10000, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("choice.ranges")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { std::vector<std::string> { "Hello", "Goodbye" } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.choice.ranges")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, std::vector<std::string> { "Hello", "Goodbye" } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=10000, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("choice.ranges.1")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { std::views::iota(0, 2) | std::views::transform([](auto i) { return std::to_string(i); }) };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("0" == window->GetString(0));
-        CHECK("1" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"0\",\"1\",)]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("setSelection")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, { "Hello", "Goodbye" } }.withSelection(1);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(2 == window->GetCount());
-        CHECK(1 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=10000, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetSelection:1",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("style")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withStyle(wxCB_SORT);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetWindowStyle() == wxCB_SORT);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=-1, pos=(-1,-1), size=(-1,-1), style=8, choices=()]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=-1, pos=(1,2), size=(-1,-1), style=0, choices=()]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=-1, pos=(-1,-1), size=(1,2), style=0, choices=()]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
+    }
+
+    SECTION("AI")
+    {
+        TestProvider provider;
+        auto uut = wxUI::Choice { { "one", "two", "three" } }.withSelection(1).bind([] {});
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxChoice[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"one\",\"two\",\"three\",)]",
+                  "SetSelection:1",
+                  "SetEnabled:true",
+                  "BindEvents:1",
+              });
     }
 
     COMMON_TESTS(ChoiceTestPolicy)

--- a/tests/wxUI_ComboBoxTests.cpp
+++ b/tests/wxUI_ComboBoxTests.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::ComboBox;
+using namespace wxUITests;
 
 struct ComboBoxTestPolicy {
     using TypeUnderTest = wxUI::ComboBox;
@@ -46,81 +47,110 @@ TEST_CASE("ComboBox")
 {
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
-    }
-
-    SECTION("choice")
-    {
-        wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxComboBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=(\"\",)]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxComboBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=()]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.choice")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, { std::string {} } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxComboBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=(\"\",)]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("choice.ranges")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { std::vector<std::string> { std::string {} } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxComboBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=(\"\",)]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.choice.ranges")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, std::vector<std::string> { std::string {} } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxComboBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\", choices=(\"\",)]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxComboBox[id=-1, pos=(1,2), size=(-1,-1), style=0, text=\"\", choices=(\"\",)]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxComboBox[id=-1, pos=(-1,-1), size=(1,2), style=0, text=\"\", choices=(\"\",)]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("setSelection")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, { "Hello", "Goodbye" } }.withSize({ 1, 2 }).withSelection(1);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(2 == window->GetCount());
-        CHECK(1 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxComboBox[id=10000, pos=(-1,-1), size=(1,2), style=0, text=\"Hello\", choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetSelection:1",
+                  "SetEnabled:true",
+              });
+    }
+
+    SECTION("AI")
+    {
+        TestProvider provider;
+        auto uut = wxUI::ComboBox { { "one", "two", "three" } }.withSelection(2).bind([] {});
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxComboBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"one\", choices=(\"one\",\"two\",\"three\",)]",
+                  "SetSelection:2",
+                  "SetEnabled:true",
+                  "BindEvents:1",
+              });
     }
 
     COMMON_TESTS(ComboBoxTestPolicy)

--- a/tests/wxUI_GaugeTests.cpp
+++ b/tests/wxUI_GaugeTests.cpp
@@ -29,11 +29,12 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Gauge;
+using namespace wxUITests;
 
 struct GaugeTestPolicy {
     using TypeUnderTest = wxUI::Gauge;
     static auto createUUT() { return TypeUnderTest {}; }
-    static auto testStyle() { return wxGA_VERTICAL; }
+    static auto testStyle() { return wxGA_HORIZONTAL; }
     static auto testPosition() { return wxPoint { 1, 2 }; }
     static auto testSize() { return wxSize { 10, 12 }; }
     static auto expectedStyle() { return testStyle(); }
@@ -46,66 +47,79 @@ TEST_CASE("Gauge")
 {
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetRange() == 100);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxGauge[id=-1, pos=(-1,-1), size=(-1,-1), style=4, value=100]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("name")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { wxUI::Gauge::withRange {}, 200 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetRange() == 200);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxGauge[id=-1, pos=(-1,-1), size=(-1,-1), style=4, value=200]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { wxUI::Gauge::withIdentity {}, 10000 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetRange() == 100);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxGauge[id=10000, pos=(-1,-1), size=(-1,-1), style=4, value=100]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.name")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { wxUI::Gauge::withIdentity {}, 10000, 200 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetRange() == 200);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxGauge[id=10000, pos=(-1,-1), size=(-1,-1), style=4, value=200]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("style")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = createUUT().setStyle(wxGA_HORIZONTAL);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetWindowStyle() == wxGA_HORIZONTAL);
+        TestProvider provider;
+        auto uut = createUUT().setStyle(wxGA_VERTICAL);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxGauge[id=-1, pos=(-1,-1), size=(-1,-1), style=8, value=100]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetRange() == 100);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxGauge[id=-1, pos=(1,2), size=(-1,-1), style=4, value=100]",
+                  "SetEnabled:true",
+              });
     }
 
-    SECTION("proxy.bind")
+    SECTION("AI")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
-        auto proxy = TypeUnderTest::Proxy {};
-        auto uut = TypeUnderTest {}.withSize({ 1, 2 }).withProxy(proxy);
-        uut.create(&frame);
-        CHECK(static_cast<int>(*proxy) == 0);
-        *proxy = 30;
-        CHECK(static_cast<int>(*proxy) == 30);
-        CHECK(static_cast<int>(proxy.range()) == 100);
-        proxy.range() = 200;
-        CHECK(static_cast<int>(proxy.range()) == 200);
+        TestProvider provider;
+        auto uut = wxUI::Gauge { wxUI::Gauge::withRange {}, 250 };
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxGauge[id=-1, pos=(-1,-1), size=(-1,-1), style=4, value=250]",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(GaugeTestPolicy)

--- a/tests/wxUI_HSplitterTests.cpp
+++ b/tests/wxUI_HSplitterTests.cpp
@@ -30,11 +30,12 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::HSplitter<wxUI::TextCtrl, wxUI::TextCtrl>;
+using namespace wxUITests;
 
 struct HSplitterTestPolicy {
     using TypeUnderTest = wxUI::HSplitter<wxUI::TextCtrl, wxUI::TextCtrl>;
     static auto createUUT() { return TypeUnderTest { wxUI::TextCtrl {}, wxUI::TextCtrl {} }; }
-    static auto testStyle() { return wxSP_LIVE_UPDATE; }
+    static auto testStyle() { return wxSP_3D | wxSP_LIVE_UPDATE; }
     static auto testPosition() { return wxPoint { 14, 2 }; }
     static auto testSize() { return wxSize { 100, 40 }; }
     static auto expectedStyle() { return testStyle(); }
@@ -46,32 +47,45 @@ TEST_CASE("HSplitter")
 {
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { wxUI::TextCtrl {}, wxUI::TextCtrl {} };
-        [[maybe_unused]] auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSplitterWindow[id=-1, pos=(-1,-1), size=(-1,-1), style=896]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SplitHorizontal:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, wxUI::TextCtrl {}, wxUI::TextCtrl {} };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-    }
-
-    SECTION("proxy")
-    {
-        wxFrame frame { nullptr, wxID_ANY, "" };
-        wxUI::SplitterProxy proxy;
-        auto uut = TypeUnderTest { wxUI::TextCtrl {}, wxUI::TextCtrl {} }.withProxy(proxy);
-        [[maybe_unused]] auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSplitterWindow[id=10000, pos=(-1,-1), size=(-1,-1), style=896]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SplitHorizontal:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("withGravity")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { wxUI::TextCtrl {}, wxUI::TextCtrl {} }.withStashGravity(1.0);
-        [[maybe_unused]] auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSplitterWindow[id=-1, pos=(-1,-1), size=(-1,-1), style=896]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SplitHorizontal:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetSashGravity:1",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(HSplitterTestPolicy)

--- a/tests/wxUI_HyperlinkTests.cpp
+++ b/tests/wxUI_HyperlinkTests.cpp
@@ -29,11 +29,12 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Hyperlink;
+using namespace wxUITests;
 
 struct HyperlinkTestPolicy {
     using TypeUnderTest = wxUI::Hyperlink;
     static auto createUUT() { return TypeUnderTest { "Hello", "www.github.com" }; }
-    static auto testStyle() { return wxHL_CONTEXTMENU; }
+    static auto testStyle() { return wxHL_DEFAULT_STYLE; }
     static auto testPosition() { return wxPoint { 1, 2 }; }
     static auto testSize() { return wxSize { 10, 12 }; }
     static auto expectedStyle() { return testStyle(); }
@@ -46,53 +47,68 @@ TEST_CASE("Hyperlink")
 {
     SECTION("name.url")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK("Hello" == window->GetLabel());
-        CHECK("www.github.com" == window->GetURL());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxHyperlinkCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=2097161, text=\"Hello\", text2=\"www.github.com\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.name.url")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, "Hello", "www.github.com" };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK("Hello" == window->GetLabel());
-        CHECK("www.github.com" == window->GetURL());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxHyperlinkCtrl[id=10000, pos=(-1,-1), size=(-1,-1), style=2097161, text=\"Hello\", text2=\"www.github.com\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("style")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK((window->GetWindowStyle() & wxHL_DEFAULT_STYLE) == wxHL_DEFAULT_STYLE);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxHyperlinkCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=2097161, text=\"Hello\", text2=\"www.github.com\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("withStyle")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withoutStyle(wxHL_ALIGN_CENTRE).withStyle(wxHL_ALIGN_LEFT);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetWindowStyle() == (wxHL_CONTEXTMENU | wxNO_BORDER | wxHL_ALIGN_LEFT));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxHyperlinkCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=2097155, text=\"Hello\", text2=\"www.github.com\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxHyperlinkCtrl[id=-1, pos=(1,2), size=(-1,-1), style=2097161, text=\"Hello\", text2=\"www.github.com\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxHyperlinkCtrl[id=-1, pos=(-1,-1), size=(1,2), style=2097161, text=\"Hello\", text2=\"www.github.com\"]",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(HyperlinkTestPolicy)

--- a/tests/wxUI_LineTests.cpp
+++ b/tests/wxUI_LineTests.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Line;
+using namespace wxUITests;
 
 struct LineTestPolicy {
     using TypeUnderTest = wxUI::Line;
@@ -46,18 +47,24 @@ TEST_CASE("Line")
 {
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window != nullptr);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxStaticLine[id=-1, pos=(-1,-1), size=(-1,-1), style=0]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxStaticLine[id=10000, pos=(-1,-1), size=(-1,-1), style=0]",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(LineTestPolicy)

--- a/tests/wxUI_ListBoxTests.cpp
+++ b/tests/wxUI_ListBoxTests.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
 using TypeUnderTest = wxUI::ListBox;
+using namespace wxUITests;
 
 struct ListBoxTestPolicy {
     using TypeUnderTest = wxUI::ListBox;
@@ -46,100 +47,104 @@ TEST_CASE("ListBox")
 {
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(0 == window->GetCount());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxListBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=()]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("ListBox")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { "Hello", "Goodbye" };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(2 == window->GetCount());
-        CHECK(wxNOT_FOUND == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxListBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(0 == window->GetCount());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxListBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, choices=()]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.ListBox")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, { "Hello", "Goodbye" } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(2 == window->GetCount());
-        CHECK(wxNOT_FOUND == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxListBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.ListBox.ranges")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, std::vector<std::string> { "Hello", "Goodbye" } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(2 == window->GetCount());
-        CHECK(wxNOT_FOUND == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxListBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("setSelection")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, { "Hello", "Goodbye" } }.withSelection(1);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(2 == window->GetCount());
-        CHECK(1 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxListBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetSelection:1",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("setSelections")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
-        wxUI::ListBox::Proxy listProxy {};
-        auto uut = TypeUnderTest { 10000, { "Hello", "Goodbye" } }.withStyle(wxLB_MULTIPLE).withSelections({ 0, 1 }).withProxy(listProxy);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(2 == window->GetCount());
-        wxArrayInt selectedItems;
-        CHECK(2 == window->GetSelections(selectedItems));
-        CHECK(wxArrayInt { 0, 1 } == selectedItems);
-        CHECK(std::vector<int> { 0, 1 } == listProxy.selections().get());
-        listProxy.selections() = { 0 };
-        CHECK(1 == window->GetSelections(selectedItems));
-        CHECK(wxArrayInt { 0 } == selectedItems);
-        std::vector<int> data = listProxy.selections();
-        CHECK(std::vector<int> { 0 } == data);
+        TestProvider provider;
+        auto uut = TypeUnderTest { 10000, { "Hello", "Goodbye" } }.withStyle(wxLB_MULTIPLE).withSelections({ 0, 1 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxListBox[id=10000, pos=(-1,-1), size=(-1,-1), style=64, choices=(\"Hello\",\"Goodbye\",)]",
+                  "SetSelection:0",
+                  "SetSelection:1",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("style")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withStyle(wxLB_MULTIPLE);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetWindowStyle() == (wxBORDER_SUNKEN | wxLB_MULTIPLE));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxListBox[id=-1, pos=(-1,-1), size=(-1,-1), style=64, choices=()]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxListBox[id=-1, pos=(1,2), size=(-1,-1), style=0, choices=()]",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(ListBoxTestPolicy)

--- a/tests/wxUI_RadioBoxTests.cpp
+++ b/tests/wxUI_RadioBoxTests.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::RadioBox;
+using namespace wxUITests;
 
 struct RadioBoxTestPolicy {
     using TypeUnderTest = wxUI::RadioBox;
@@ -46,130 +47,138 @@ TEST_CASE("RadioBox")
 {
     SECTION("choices")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("name.choice")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         using namespace std::literals;
         auto uut = TypeUnderTest { "Greetings", TypeUnderTest::withChoices {}, { "Hello"s, "Goodbye"s } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK("Greetings" == window->GetLabel());
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"Greetings\", choices=(\"Hello\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.choices")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         using namespace std::literals;
         auto uut = TypeUnderTest { 10000, TypeUnderTest::withChoices {}, { "Hello"s, "Goodbye"s } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxRadioBox[id=10000, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.name.choice")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, "Greetings", TypeUnderTest::withChoices {}, { "Hello", "Goodbye" } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK("Greetings" == window->GetLabel());
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxRadioBox[id=10000, pos=(-1,-1), size=(-1,-1), style=4, text=\"Greetings\", choices=(\"Hello\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("choices.ranges")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { TypeUnderTest::withChoices {}, std::vector<std::string> { "Hello", "Goodbye" } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("name.choice.ranges")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         using namespace std::literals;
         auto uut = TypeUnderTest { "Greetings", TypeUnderTest::withChoices {}, std::vector<std::string> { "Hello"s, "Goodbye"s } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK("Greetings" == window->GetLabel());
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"Greetings\", choices=(\"Hello\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.choices.ranges")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         using namespace std::literals;
         auto uut = TypeUnderTest { 10000, TypeUnderTest::withChoices {}, std::vector<std::string> { "Hello"s, "Goodbye"s } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxRadioBox[id=10000, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.name.choice.ranges")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, "Greetings", TypeUnderTest::withChoices {}, std::vector<std::string> { "Hello", "Goodbye" } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK("Greetings" == window->GetLabel());
-        CHECK(2 == window->GetCount());
-        CHECK(0 == window->GetSelection());
-        CHECK("Hello" == window->GetString(0));
-        CHECK("Goodbye" == window->GetString(1));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxRadioBox[id=10000, pos=(-1,-1), size=(-1,-1), style=4, text=\"Greetings\", choices=(\"Hello\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("style")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withStyle(wxRA_SPECIFY_COLS);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetWindowStyle() == (wxRA_SPECIFY_COLS | wxTAB_TRAVERSAL));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxRadioBox[id=-1, pos=(1,2), size=(-1,-1), style=4, text=\"\", choices=(\"Hello\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxRadioBox[id=-1, pos=(-1,-1), size=(1,2), style=4, text=\"\", choices=(\"Hello\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(RadioBoxTestPolicy)

--- a/tests/wxUI_SliderTests.cpp
+++ b/tests/wxUI_SliderTests.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Slider;
+using namespace wxUITests;
 
 struct SliderTestPolicy {
     using TypeUnderTest = wxUI::Slider;
@@ -37,8 +38,8 @@ struct SliderTestPolicy {
     static auto testPosition() { return wxPoint { 14, 2 }; }
     static auto testSize() { return wxSize { 100, 40 }; }
     static auto expectedStyle() { return testStyle(); }
-    static auto expectedPosition() { return wxPoint { 18, 2 }; }
-    static auto expectedSize() { return wxSize { 85, 40 }; }
+    static auto expectedPosition() { return testPosition(); }
+    static auto expectedSize() { return testSize(); }
 };
 static auto createUUT() { return SliderTestPolicy::createUUT(); }
 
@@ -46,53 +47,80 @@ TEST_CASE("Slider")
 {
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetValue() == 0);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSlider[id=-1, pos=(-1,-1), size=(-1,-1), style=0, value=0, range=[0,100]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("range")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { std::pair { 1, 5 } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetValue() == 1);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSlider[id=-1, pos=(-1,-1), size=(-1,-1), style=0, value=1, range=[1,5]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("range.init")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { std::pair { 1, 5 }, 3 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetValue() == 3);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSlider[id=-1, pos=(-1,-1), size=(-1,-1), style=0, value=3, range=[1,5]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetValue() == 0);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSlider[id=10000, pos=(-1,-1), size=(-1,-1), style=0, value=0, range=[0,100]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.range")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, std::pair { 1, 5 } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetValue() == 1);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSlider[id=10000, pos=(-1,-1), size=(-1,-1), style=0, value=1, range=[1,5]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.range.init")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, std::pair { 1, 5 }, 3 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetValue() == 3);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSlider[id=10000, pos=(-1,-1), size=(-1,-1), style=0, value=3, range=[1,5]]",
+                  "SetEnabled:true",
+              });
+    }
+
+    SECTION("AI")
+    {
+        TestProvider provider;
+        auto uut = wxUI::Slider { { 10, 20 }, 12 }.bind([] {});
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSlider[id=-1, pos=(-1,-1), size=(-1,-1), style=0, value=12, range=[10,20]]",
+                  "SetEnabled:true",
+                  "BindEvents:1",
+              });
     }
 
     COMMON_TESTS(SliderTestPolicy)

--- a/tests/wxUI_SpinCtrlTests.cpp
+++ b/tests/wxUI_SpinCtrlTests.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::SpinCtrl;
+using namespace wxUITests;
 
 struct SpinCtrlTestPolicy {
     using TypeUnderTest = wxUI::SpinCtrl;
@@ -46,95 +47,114 @@ TEST_CASE("SpinCtrl")
 {
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetValue() == 0);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSpinCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, value=0, range=[0,100]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("range")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { std::pair { 1, 5 } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetValue() == 1);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSpinCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, value=1, range=[1,5]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("range.init")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { std::pair { 1, 5 }, 3 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetValue() == 3);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSpinCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, value=3, range=[1,5]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetValue() == 0);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSpinCtrl[id=10000, pos=(-1,-1), size=(-1,-1), style=0, value=0, range=[0,100]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.range")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, std::pair { 1, 5 } };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetValue() == 1);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSpinCtrl[id=10000, pos=(-1,-1), size=(-1,-1), style=0, value=1, range=[1,5]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.range.init")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, std::pair { 1, 5 }, 3 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetValue() == 3);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSpinCtrl[id=10000, pos=(-1,-1), size=(-1,-1), style=0, value=3, range=[1,5]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("style")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withStyle(wxTE_PROCESS_ENTER);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetWindowStyle() == (wxTE_PROCESS_ENTER | wxTAB_TRAVERSAL | 0x200000));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSpinCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=1024, value=0, range=[0,100]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSpinCtrl[id=-1, pos=(1,2), size=(-1,-1), style=0, value=0, range=[0,100]]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSpinCtrl[id=-1, pos=(-1,-1), size=(1,2), style=0, value=0, range=[0,100]]",
+                  "SetEnabled:true",
+              });
     }
 
-    SECTION("proxy")
+    SECTION("AI")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
-        auto proxy = TypeUnderTest::Proxy {};
-        auto uut = createUUT().withSize({ 1, 2 }).withProxy(proxy);
-        uut.create(&frame);
-
-        CHECK(*proxy == 0);
-        *proxy = 1;
-        CHECK(*proxy == 1);
-        *proxy = 2;
-        CHECK(*proxy == 2);
-        int result2 = *proxy;
-        CHECK(result2 == 2);
+        TestProvider provider;
+        auto uut = wxUI::SpinCtrl { { 0, 10 }, 3 }.bind([] {});
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSpinCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, value=3, range=[0,10]]",
+                  "SetEnabled:true",
+                  "BindEvents:1",
+              });
     }
-
     COMMON_TESTS(SpinCtrlTestPolicy)
 }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_TextCtrlTests.cpp
+++ b/tests/wxUI_TextCtrlTests.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::TextCtrl;
+using namespace wxUITests;
 
 struct TextCtrlTestPolicy {
     using TypeUnderTest = wxUI::TextCtrl;
@@ -44,69 +45,81 @@ static auto createUUT() { return TextCtrlTestPolicy::createUUT(); }
 
 TEST_CASE("TextCtrl")
 {
-    SECTION("noargs.1")
-    {
-        wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
-    }
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("name")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { "Hello" };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK("Hello" == window->GetValue());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxTextCtrl[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.name")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, "Hello" };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK("Hello" == window->GetValue());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxTextCtrl[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("style")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withStyle(wxTE_PROCESS_ENTER);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetWindowStyle() == (wxBORDER_SUNKEN | wxTE_PROCESS_ENTER));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=1024, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxTextCtrl[id=-1, pos=(1,2), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxTextCtrl[id=-1, pos=(-1,-1), size=(1,2), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(TextCtrlTestPolicy)

--- a/tests/wxUI_TextTests.cpp
+++ b/tests/wxUI_TextTests.cpp
@@ -29,6 +29,7 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::Text;
+using namespace wxUITests;
 
 struct TextTestPolicy {
     using TypeUnderTest = wxUI::Text;
@@ -44,87 +45,81 @@ static auto createUUT() { return TextTestPolicy::createUUT(); }
 
 TEST_CASE("Text")
 {
-    SECTION("noargs.1")
-    {
-        wxFrame frame { nullptr, wxID_ANY, "" };
-        auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
-    }
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT();
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxStaticText[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("name")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { "Hello" };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK("Hello" == window->GetLabel());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxStaticText[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000 };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK(window->GetLabel().empty());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxStaticText[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id.name")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, "Hello" };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-        CHECK("Hello" == window->GetLabel());
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxStaticText[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("style")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withStyle(wxST_ELLIPSIZE_MIDDLE);
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetWindowStyle() == wxST_ELLIPSIZE_MIDDLE);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxStaticText[id=-1, pos=(-1,-1), size=(-1,-1), style=8, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("pos")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withPosition({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetPosition() == wxPoint { 1, 2 });
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxStaticText[id=-1, pos=(1,2), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("size")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = createUUT().withSize({ 1, 2 });
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(window->GetSize() == wxSize { 1, 2 });
-    }
-
-    SECTION("proxy.bind")
-    {
-        wxFrame frame { nullptr, wxID_ANY, "" };
-        auto proxy = TypeUnderTest::Proxy {};
-        auto uut = TypeUnderTest { "label1" }.withSize({ 1, 2 }).withProxy(proxy);
-        uut.create(&frame);
-        CHECK(static_cast<std::string>(*proxy) == std::string("label1"));
-        //        CHECK(static_cast<std::string>(proxy) == "label1");
-        //        CHECK("label1" == static_cast<std::string>(proxy));
-        //        CHECK(static_cast<std::string>(proxy) == "label1");
-        *proxy = "label2";
-        CHECK(static_cast<std::string>(*proxy) == "label2");
-        *proxy = "label3";
-        CHECK(static_cast<std::string>(*proxy) == "label3");
-        std::string result2 = *proxy;
-        CHECK(result2 == "label3");
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxStaticText[id=-1, pos=(-1,-1), size=(1,2), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(TextTestPolicy)

--- a/tests/wxUI_VSplitterTests.cpp
+++ b/tests/wxUI_VSplitterTests.cpp
@@ -30,11 +30,12 @@ SOFTWARE.
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
 using TypeUnderTest = wxUI::VSplitter<wxUI::TextCtrl, wxUI::TextCtrl>;
+using namespace wxUITests;
 
 struct VSplitterTestPolicy {
     using TypeUnderTest = wxUI::VSplitter<wxUI::TextCtrl, wxUI::TextCtrl>;
     static auto createUUT() { return TypeUnderTest { wxUI::TextCtrl {}, wxUI::TextCtrl {} }; }
-    static auto testStyle() { return wxSP_LIVE_UPDATE; }
+    static auto testStyle() { return wxSP_3D | wxSP_LIVE_UPDATE; }
     static auto testPosition() { return wxPoint { 14, 2 }; }
     static auto testSize() { return wxSize { 100, 40 }; }
     static auto expectedStyle() { return testStyle(); }
@@ -46,32 +47,45 @@ TEST_CASE("VSplitter")
 {
     SECTION("noargs")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { wxUI::TextCtrl {}, wxUI::TextCtrl {} };
-        [[maybe_unused]] auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSplitterWindow[id=-1, pos=(-1,-1), size=(-1,-1), style=896]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SplitVertical:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("id")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { 10000, wxUI::TextCtrl {}, wxUI::TextCtrl {} };
-        auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
-        CHECK(10000 == window->GetId());
-    }
-
-    SECTION("proxy")
-    {
-        wxFrame frame { nullptr, wxID_ANY, "" };
-        wxUI::SplitterProxy proxy;
-        auto uut = TypeUnderTest { wxUI::TextCtrl {}, wxUI::TextCtrl {} }.withProxy(proxy);
-        [[maybe_unused]] auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSplitterWindow[id=10000, pos=(-1,-1), size=(-1,-1), style=896]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SplitVertical:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetEnabled:true",
+              });
     }
 
     SECTION("withGravity")
     {
-        wxFrame frame { nullptr, wxID_ANY, "" };
+        TestProvider provider;
         auto uut = TypeUnderTest { wxUI::TextCtrl {}, wxUI::TextCtrl {} }.withStashGravity(1.0);
-        [[maybe_unused]] auto* window = dynamic_cast<TypeUnderTest::underlying_t*>(uut.create(&frame));
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "controller:wxSplitterWindow[id=-1, pos=(-1,-1), size=(-1,-1), style=896]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "Create:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SplitVertical:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]:wxTextCtrl[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+                  "SetSashGravity:1",
+                  "SetEnabled:true",
+              });
     }
 
     COMMON_TESTS(VSplitterTestPolicy)


### PR DESCRIPTION
…low for testability

Making the way that we use Parent to be more generic, as it essentially is the thing that can create new controllers. Using customaization functions and CPO to allow exentsion to types that conform to the API.  This allows something like TestProvider. Moving tests to not rely on creating a wxWidget frame, which has major problems on windows, and on recent versions of wxWidgets.