### PR TITLE
Issue #274: ASAN failure with when using ComboBox { { hello, goodbye } }

### DIFF
--- a/LATEST_RELEASE_NOTES.md
+++ b/LATEST_RELEASE_NOTES.md
@@ -2,6 +2,9 @@
 
 Bugs addressed in this release:
 
+* [#255](../../issues/255) Missed some std::string that should be std::string_view
+* [#274](../../issues/274) ASAN failure with when using ComboBox { { hello, goodbye } }
+
 Other changes:
 
 * [#23](../../issues/23) Add a cmake alias
@@ -9,6 +12,5 @@ Other changes:
 * [#42](../../issues/42) Why does clang-format not like concepts?
 * [#233](../../issues/233) We should figure out the best long term header layout
 * [#254](../../issues/254) Generic is too generic. Split into Wrapper and Factory
-* [#255](../../issues/255) Missed some std::string that should be std::string_view
 * [#256](../../issues/256) Proxy should follow controller_ convention
 

--- a/docs/ProgrammersGuide.md
+++ b/docs/ProgrammersGuide.md
@@ -337,26 +337,24 @@ Often times you would be laying out a set of buttons in a horizontal sizer.  The
 `HSplitter` and `VSplitter` are special types of *Layout* objects that take in two *Controllers*.
 
 ```cpp
-    VSizer
-    {
+    VSizer {
         wxSizerFlags().Expand().Border(),
-            VSplitter {
-                TextCtrl { "This is Left Side.\n" }
-                    .withStyle(wxTE_MULTILINE)
-                    .withSize(wxSize(200, 100)),
-                HSplitter {
-                    TextCtrl { "This is Right Top.\n" }.withProxy(rightUpper).withStyle(wxTE_MULTILINE).withSize(wxSize(200, 100)),
-                    Button { "Incr" }
-                        .bind([this]() {
-                            auto original = std::string { *rightUpper } + "\nThis is Right Top.\n";
-                            *rightUpper = original;
-                        }),
-                }
-            },
+        VSplitter {
+            TextCtrl { "This is Left Side.\n" }
+                .withStyle(wxTE_MULTILINE)
+                .withSize(wxSize(200, 100)),
+            HSplitter {
+                TextCtrl { "This is Right Top.\n" }.withProxy(rightUpper).withStyle(wxTE_MULTILINE).withSize(wxSize(200, 100)),
+                Button { "Incr" }
+                    .bind([this]() {
+                        auto original = std::string { *rightUpper } + "\nThis is Right Top.\n";
+                        *rightUpper = original;
+                    }),
+            } },
     // ...
-            CreateStdDialogButtonSizer(wxOK),
+        CreateStdDialogButtonSizer(wxOK),
     }
-    .fitTo(this);
+        .fitTo(this);
 ```
 
 Note: Because the Splitter requires both parts to be children of the Splitter itself, you cannot use `Wrapper` as a *Controller*.  This will not compile:

--- a/examples/HelloWorld/ExtendedExample.cpp
+++ b/examples/HelloWorld/ExtendedExample.cpp
@@ -29,8 +29,8 @@ SOFTWARE.
 
 ExtendedExample::ExtendedExample(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, "ExtendedExample",
-        wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+          wxDefaultPosition, wxDefaultSize,
+          wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     using namespace wxUI;
     ComboBox::Proxy proxy2;
@@ -76,7 +76,7 @@ ExtendedExample::ExtendedExample(wxWindow* parent)
             CheckBox {},
         },
         HSizer {
-            ComboBox { { "hello" } }.withProxy(proxy2),
+            ComboBox { "hello" }.withProxy(proxy2),
         },
         HSizer {
             Line {},
@@ -159,30 +159,28 @@ SplitterExample::SplitterExample(wxWindow* parent)
     using namespace wxUI;
     Factory<wxButton>::Proxy proxy {};
     // snippet SplitterExample
-    VSizer
-    {
+    VSizer {
         wxSizerFlags().Expand().Border(),
-            VSplitter {
-                TextCtrl { "This is Left Side.\n" }
-                    .withStyle(wxTE_MULTILINE)
-                    .withSize(wxSize(200, 100)),
-                HSplitter {
-                    TextCtrl { "This is Right Top.\n" }.withProxy(rightUpper).withStyle(wxTE_MULTILINE).withSize(wxSize(200, 100)),
-                    Button { "Incr" }
-                        .bind([this]() {
-                            auto original = std::string { *rightUpper } + "\nThis is Right Top.\n";
-                            *rightUpper = original;
-                        }),
-                }
-            },
-            // endsnippet SplitterExample
-            VSplitter {
-                TextCtrl {}.withStyle(wxTE_MULTILINE | wxHSCROLL | wxTE_PROCESS_TAB),
-                Factory {
-                    [](wxWindow* parent) {
-                        return new wxButton(parent, wxID_ANY, "Raw button");
-                    } },
-            },
+        VSplitter {
+            TextCtrl { "This is Left Side.\n" }
+                .withStyle(wxTE_MULTILINE)
+                .withSize(wxSize(200, 100)),
+            HSplitter {
+                TextCtrl { "This is Right Top.\n" }.withProxy(rightUpper).withStyle(wxTE_MULTILINE).withSize(wxSize(200, 100)),
+                Button { "Incr" }
+                    .bind([this]() {
+                        auto original = std::string { *rightUpper } + "\nThis is Right Top.\n";
+                        *rightUpper = original;
+                    }),
+            } },
+        // endsnippet SplitterExample
+        VSplitter {
+            TextCtrl {}.withStyle(wxTE_MULTILINE | wxHSCROLL | wxTE_PROCESS_TAB),
+            Factory {
+                [](wxWindow* parent) {
+                    return new wxButton(parent, wxID_ANY, "Raw button");
+                } },
+        },
 #if 0
         // snippet SplitterCompileFail
         // This is not supported because the splitter needs to have the controls created with wxSplitterWindow as parent.
@@ -195,17 +193,17 @@ SplitterExample::SplitterExample(wxWindow* parent)
         },
         // endsnippet SplitterCompileFail
 #endif
-            VSplitter {
-                Factory<wxButton> { [](wxWindow* parent) {
-                    return new wxButton(parent, wxID_ANY, "Raw button");
-                } }
-                    .withProxy(proxy),
-                TextCtrl {}.withStyle(wxTE_MULTILINE | wxHSCROLL | wxTE_PROCESS_TAB),
-            },
-            // snippet SplitterExample
-            CreateStdDialogButtonSizer(wxOK),
+        VSplitter {
+            Factory<wxButton> { [](wxWindow* parent) {
+                return new wxButton(parent, wxID_ANY, "Raw button");
+            } }
+                .withProxy(proxy),
+            TextCtrl {}.withStyle(wxTE_MULTILINE | wxHSCROLL | wxTE_PROCESS_TAB),
+        },
+        // snippet SplitterExample
+        CreateStdDialogButtonSizer(wxOK),
     }
-    .fitTo(this);
+        .fitTo(this);
     // endsnippet SplitterExample
     *rightUpper = std::string { proxy->GetLabel() };
 }
@@ -466,8 +464,8 @@ auto MakeLayout(bool layout)
 
 LayoutIfExample::LayoutIfExample(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, "LayoutIf",
-        wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+          wxDefaultPosition, wxDefaultSize,
+          wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     using namespace wxUI;
     VSizer {
@@ -480,8 +478,8 @@ LayoutIfExample::LayoutIfExample(wxWindow* parent)
 
 WrapSizerExample::WrapSizerExample(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, "WrapSizer",
-        wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+          wxDefaultPosition, wxDefaultSize,
+          wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     using namespace wxUI;
     VSizer {
@@ -502,8 +500,8 @@ WrapSizerExample::WrapSizerExample(wxWindow* parent)
 
 GridSizerExample::GridSizerExample(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, "GridSizer",
-        wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+          wxDefaultPosition, wxDefaultSize,
+          wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     using namespace wxUI;
     GridSizer {
@@ -519,8 +517,8 @@ GridSizerExample::GridSizerExample(wxWindow* parent)
 
 FlexGridSizerExample::FlexGridSizerExample(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, "FlexGridSizer",
-        wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+          wxDefaultPosition, wxDefaultSize,
+          wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     using namespace wxUI;
     // snippet FlexGridSizerExample
@@ -538,8 +536,8 @@ FlexGridSizerExample::FlexGridSizerExample(wxWindow* parent)
 
 UnicodeExample::UnicodeExample(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, "LayoutIf",
-        wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+          wxDefaultPosition, wxDefaultSize,
+          wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     using namespace wxUI;
     // snippet UnicodeExample

--- a/include/wxUI/Choice.hpp
+++ b/include/wxUI/Choice.hpp
@@ -35,8 +35,41 @@ namespace wxUI {
 struct Choice {
     using underlying_t = wxChoice;
 
+    explicit Choice(std::initializer_list<char const*> choices)
+        : Choice(wxID_ANY, choices)
+    {
+    }
+
+    explicit Choice(std::initializer_list<std::initializer_list<char const*>> choices)
+        : Choice(wxID_ANY, choices)
+    {
+    }
+
+    explicit Choice(std::initializer_list<std::string_view> choices)
+        : Choice(wxID_ANY, choices)
+    {
+    }
+
     explicit Choice(std::initializer_list<std::string> choices = {})
         : Choice(wxID_ANY, choices)
+    {
+    }
+
+    explicit Choice(wxWindowID identity, std::initializer_list<char const*> choices)
+        : details_(identity)
+        , choices_(details::Ranges::convertToUtf8(choices))
+    {
+    }
+
+    explicit Choice(wxWindowID identity, std::initializer_list<std::initializer_list<char const*>> choices)
+        : details_(identity)
+        , choices_(details::Ranges::flattenToUtf8(choices))
+    {
+    }
+
+    explicit Choice(wxWindowID identity, std::initializer_list<std::string_view> choices)
+        : details_(identity)
+        , choices_(details::Ranges::convertToUtf8(choices))
     {
     }
 
@@ -46,14 +79,14 @@ struct Choice {
     {
     }
 
-    explicit Choice(details::Ranges::input_range_of<wxString> auto&& choices)
+    explicit Choice(details::Ranges::utf8_text_input_range auto&& choices)
         : Choice(wxID_ANY, std::forward<decltype(choices)>(choices))
     {
     }
 
-    Choice(wxWindowID identity, details::Ranges::input_range_of<wxString> auto&& choices)
+    Choice(wxWindowID identity, details::Ranges::utf8_text_input_range auto&& choices)
         : details_(identity)
-        , choices_(details::Ranges::ToVector<wxString>(std::forward<decltype(choices)>(choices)))
+        , choices_(details::Ranges::ToVectorUtf8(std::forward<decltype(choices)>(choices)))
     {
     }
 

--- a/include/wxUI/ComboBox.hpp
+++ b/include/wxUI/ComboBox.hpp
@@ -35,8 +35,41 @@ namespace wxUI {
 struct ComboBox {
     using underlying_t = wxComboBox;
 
+    ComboBox(std::initializer_list<char const*> choices)
+        : ComboBox(wxID_ANY, choices)
+    {
+    }
+
+    ComboBox(std::initializer_list<std::initializer_list<char const*>> choices)
+        : ComboBox(wxID_ANY, choices)
+    {
+    }
+
+    ComboBox(std::initializer_list<std::string_view> choices)
+        : ComboBox(wxID_ANY, choices)
+    {
+    }
+
     ComboBox(std::initializer_list<std::string> choices = {})
         : ComboBox(wxID_ANY, choices)
+    {
+    }
+
+    explicit ComboBox(wxWindowID identity, std::initializer_list<char const*> choices)
+        : details_(identity)
+        , choices_(details::Ranges::convertToUtf8(choices))
+    {
+    }
+
+    explicit ComboBox(wxWindowID identity, std::initializer_list<std::initializer_list<char const*>> choices)
+        : details_(identity)
+        , choices_(details::Ranges::flattenToUtf8(choices))
+    {
+    }
+
+    explicit ComboBox(wxWindowID identity, std::initializer_list<std::string_view> choices)
+        : details_(identity)
+        , choices_(details::Ranges::convertToUtf8(choices))
     {
     }
 
@@ -46,21 +79,27 @@ struct ComboBox {
     {
     }
 
-    explicit ComboBox(details::Ranges::input_range_of<wxString> auto&& choices)
+    explicit ComboBox(details::Ranges::utf8_text_input_range auto&& choices)
         : ComboBox(wxID_ANY, std::forward<decltype(choices)>(choices))
     {
     }
 
-    ComboBox(wxWindowID identity, details::Ranges::input_range_of<wxString> auto&& choices)
+    ComboBox(wxWindowID identity, details::Ranges::utf8_text_input_range auto&& choices)
         : details_(identity)
-        , choices_(details::Ranges::ToVector<wxString>(std::forward<decltype(choices)>(choices)))
+        , choices_(details::Ranges::ToVectorUtf8(std::forward<decltype(choices)>(choices)))
     {
     }
 
-    auto withSelection(int which) -> ComboBox&
+    auto withSelection(int which) & -> ComboBox&
     {
         selection_ = which;
         return *this;
+    }
+
+    auto withSelection(int which) && -> ComboBox&&
+    {
+        selection_ = which;
+        return std::move(*this);
     }
 
     template <typename Function>

--- a/include/wxUI/ListBox.hpp
+++ b/include/wxUI/ListBox.hpp
@@ -35,8 +35,41 @@ namespace wxUI {
 struct ListBox {
     using underlying_t = wxListBox;
 
+    explicit ListBox(std::initializer_list<char const*> choices)
+        : ListBox(wxID_ANY, choices)
+    {
+    }
+
+    explicit ListBox(std::initializer_list<std::initializer_list<char const*>> choices)
+        : ListBox(wxID_ANY, choices)
+    {
+    }
+
+    explicit ListBox(std::initializer_list<std::string_view> choices)
+        : ListBox(wxID_ANY, choices)
+    {
+    }
+
     explicit ListBox(std::initializer_list<std::string> choices = {})
         : ListBox(wxID_ANY, choices)
+    {
+    }
+
+    explicit ListBox(wxWindowID identity, std::initializer_list<char const*> choices)
+        : details_(identity)
+        , choices_(details::Ranges::convertToUtf8(choices))
+    {
+    }
+
+    explicit ListBox(wxWindowID identity, std::initializer_list<std::initializer_list<char const*>> choices)
+        : details_(identity)
+        , choices_(details::Ranges::flattenToUtf8(choices))
+    {
+    }
+
+    explicit ListBox(wxWindowID identity, std::initializer_list<std::string_view> choices)
+        : details_(identity)
+        , choices_(details::Ranges::convertToUtf8(choices))
     {
     }
 
@@ -46,14 +79,14 @@ struct ListBox {
     {
     }
 
-    explicit ListBox(details::Ranges::input_range_of<wxString> auto&& choices)
+    explicit ListBox(details::Ranges::utf8_text_input_range auto&& choices)
         : ListBox(wxID_ANY, std::forward<decltype(choices)>(choices))
     {
     }
 
-    ListBox(wxWindowID identity, details::Ranges::input_range_of<wxString> auto&& choices)
+    ListBox(wxWindowID identity, details::Ranges::utf8_text_input_range auto&& choices)
         : details_(identity)
-        , choices_(details::Ranges::ToVector<wxString>(std::forward<decltype(choices)>(choices)))
+        , choices_(details::Ranges::ToVectorUtf8(std::forward<decltype(choices)>(choices)))
     {
     }
 

--- a/include/wxUI/RadioBox.hpp
+++ b/include/wxUI/RadioBox.hpp
@@ -38,8 +38,58 @@ struct RadioBox {
 
     using underlying_t = wxRadioBox;
 
+    RadioBox(withChoices unused, char const* choice)
+        : RadioBox(wxID_ANY, "", unused, { choice })
+    {
+    }
+
+    RadioBox(withChoices unused, std::string const& choice)
+        : RadioBox(wxID_ANY, "", unused, { choice })
+    {
+    }
+
+    RadioBox(withChoices unused, std::initializer_list<char const*> choices)
+        : RadioBox(wxID_ANY, "", unused, choices)
+    {
+    }
+
+    RadioBox(withChoices unused, std::initializer_list<std::initializer_list<char const*>> choices)
+        : RadioBox(wxID_ANY, "", unused, choices)
+    {
+    }
+
+    RadioBox(withChoices unused, std::initializer_list<std::string_view> choices)
+        : RadioBox(wxID_ANY, "", unused, choices)
+    {
+    }
+
     RadioBox(withChoices unused, std::initializer_list<std::string> choices)
         : RadioBox(wxID_ANY, "", unused, choices)
+    {
+    }
+
+    RadioBox(wxWindowID identity, withChoices unused, char const* choice)
+        : RadioBox(identity, "", unused, { choice })
+    {
+    }
+
+    RadioBox(wxWindowID identity, withChoices unused, std::string const& choice)
+        : RadioBox(identity, "", unused, { choice })
+    {
+    }
+
+    RadioBox(wxWindowID identity, withChoices unused, std::initializer_list<char const*> choices)
+        : RadioBox(identity, "", unused, choices)
+    {
+    }
+
+    RadioBox(wxWindowID identity, withChoices unused, std::initializer_list<std::initializer_list<char const*>> choices)
+        : RadioBox(identity, "", unused, choices)
+    {
+    }
+
+    RadioBox(wxWindowID identity, withChoices unused, std::initializer_list<std::string_view> choices)
+        : RadioBox(identity, "", unused, choices)
     {
     }
 
@@ -48,14 +98,88 @@ struct RadioBox {
     {
     }
 
+    RadioBox(std::string const& text, withChoices unused, char const* choice)
+        : RadioBox(wxID_ANY, text, unused, { choice })
+    {
+    }
+
+    RadioBox(std::string const& text, withChoices unused, std::string const& choice)
+        : RadioBox(wxID_ANY, text, unused, { choice })
+    {
+    }
+
+    RadioBox(std::string const& text, withChoices unused, std::initializer_list<char const*> choices)
+        : RadioBox(wxID_ANY, text, unused, choices)
+    {
+    }
+
+    RadioBox(std::string const& text, withChoices unused, std::initializer_list<std::initializer_list<char const*>> choices)
+        : RadioBox(wxID_ANY, text, unused, choices)
+    {
+    }
+
+    RadioBox(std::string const& text, withChoices unused, std::initializer_list<std::string_view> choices)
+        : RadioBox(wxID_ANY, text, unused, choices)
+    {
+    }
+
     RadioBox(std::string const& text, withChoices unused, std::initializer_list<std::string> choices)
         : RadioBox(wxID_ANY, text, unused, choices)
+    {
+    }
+
+    RadioBox(wxWindowID identity, std::string const& text, withChoices unused, char const* choice)
+        : RadioBox(identity, text, unused, { choice })
+    {
+    }
+
+    RadioBox(wxWindowID identity, std::string const& text, withChoices unused, std::string const& choice)
+        : RadioBox(identity, text, unused, { choice })
+    {
+    }
+
+    RadioBox(wxWindowID identity, std::string const& text, withChoices unused, std::initializer_list<char const*> choices)
+        : RadioBox(identity, wxUI_String {}, wxString::FromUTF8(text.data(), text.size()), unused, choices)
+    {
+    }
+
+    RadioBox(wxWindowID identity, std::string const& text, withChoices unused, std::initializer_list<std::initializer_list<char const*>> choices)
+        : RadioBox(identity, wxUI_String {}, wxString::FromUTF8(text.data(), text.size()), unused, choices)
+    {
+    }
+
+    RadioBox(wxWindowID identity, std::string const& text, withChoices unused, std::initializer_list<std::string_view> choices)
+        : RadioBox(identity, wxUI_String {}, wxString::FromUTF8(text.data(), text.size()), unused, choices)
     {
     }
 
     RadioBox(wxWindowID identity, std::string const& text, withChoices unused, std::initializer_list<std::string> choices)
         : RadioBox(identity, wxUI_String {}, wxString::FromUTF8(text.data(), text.size()), unused, choices)
     {
+    }
+
+    RadioBox(wxWindowID identity, wxUI_String, wxString text, withChoices, std::initializer_list<char const*> choices)
+        : details_(identity)
+        , text_(std::move(text))
+        , choices_(details::Ranges::convertToUtf8(choices))
+    {
+        details_.setStyle(wxRA_SPECIFY_COLS);
+    }
+
+    RadioBox(wxWindowID identity, wxUI_String, wxString text, withChoices, std::initializer_list<std::initializer_list<char const*>> choices)
+        : details_(identity)
+        , text_(std::move(text))
+        , choices_(details::Ranges::flattenToUtf8(choices))
+    {
+        details_.setStyle(wxRA_SPECIFY_COLS);
+    }
+
+    RadioBox(wxWindowID identity, wxUI_String, wxString text, withChoices, std::initializer_list<std::string_view> choices)
+        : details_(identity)
+        , text_(std::move(text))
+        , choices_(details::Ranges::convertToUtf8(choices))
+    {
+        details_.setStyle(wxRA_SPECIFY_COLS);
     }
 
     RadioBox(wxWindowID identity, wxUI_String, wxString text, withChoices, std::initializer_list<std::string> choices)
@@ -66,30 +190,30 @@ struct RadioBox {
         details_.setStyle(wxRA_SPECIFY_COLS);
     }
 
-    explicit RadioBox(withChoices unused, details::Ranges::input_range_of<wxString> auto&& choices)
+    explicit RadioBox(withChoices unused, details::Ranges::utf8_text_input_range auto&& choices)
         : RadioBox(wxID_ANY, "", unused, std::forward<decltype(choices)>(choices))
     {
     }
 
-    RadioBox(wxWindowID identity, withChoices unused, details::Ranges::input_range_of<wxString> auto&& choices)
+    RadioBox(wxWindowID identity, withChoices unused, details::Ranges::utf8_text_input_range auto&& choices)
         : RadioBox(identity, "", unused, std::forward<decltype(choices)>(choices))
     {
     }
 
-    RadioBox(std::string const& text, withChoices unused, details::Ranges::input_range_of<wxString> auto&& choices)
+    RadioBox(std::string const& text, withChoices unused, details::Ranges::utf8_text_input_range auto&& choices)
         : RadioBox(wxID_ANY, text, unused, std::forward<decltype(choices)>(choices))
     {
     }
 
-    RadioBox(wxWindowID identity, std::string const& text, withChoices unused, details::Ranges::input_range_of<wxString> auto&& choices)
+    RadioBox(wxWindowID identity, std::string const& text, withChoices unused, details::Ranges::utf8_text_input_range auto&& choices)
         : RadioBox(identity, wxUI_String {}, wxString::FromUTF8(text.data(), text.size()), unused, std::forward<decltype(choices)>(choices))
     {
     }
 
-    RadioBox(wxWindowID identity, wxUI_String, wxString text, withChoices, details::Ranges::input_range_of<wxString> auto&& choices)
+    RadioBox(wxWindowID identity, wxUI_String, wxString text, withChoices, details::Ranges::utf8_text_input_range auto&& choices)
         : details_(identity)
         , text_(std::move(text))
-        , choices_(details::Ranges::ToVector<wxString>(std::forward<decltype(choices)>(choices)))
+        , choices_(details::Ranges::ToVectorUtf8(std::forward<decltype(choices)>(choices)))
     {
         details_.setStyle(wxRA_SPECIFY_COLS);
     }

--- a/include/wxUI/Widget.hpp
+++ b/include/wxUI/Widget.hpp
@@ -28,9 +28,11 @@ SOFTWARE.
 #include <wxUI/detail/BindInfo.hpp>
 #include <wxUI/wxUITypes.hpp>
 
+#include <array>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <wx/sizer.h>
 #include <wx/string.h>
@@ -76,8 +78,106 @@ inline auto convertTo(std::initializer_list<T> choices) -> std::vector<wxString>
     return result;
 }
 
+inline auto convertToUtf8(std::initializer_list<char const*> choices) -> std::vector<wxString>
+{
+    auto result = std::vector<wxString> {};
+    result.reserve(choices.size());
+    for (auto const* choice : choices) {
+        result.push_back(wxString::FromUTF8(choice));
+    }
+    return result;
+}
+
+inline auto convertToUtf8(std::initializer_list<std::string_view> choices) -> std::vector<wxString>
+{
+    auto result = std::vector<wxString> {};
+    result.reserve(choices.size());
+    for (auto const choice : choices) {
+        result.push_back(wxString::FromUTF8(std::string(choice)));
+    }
+    return result;
+}
+
+template <size_t N>
+inline auto convertToUtf8(std::array<char const*, N> const& choices) -> std::vector<wxString>
+{
+    auto result = std::vector<wxString> {};
+    result.reserve(choices.size());
+    for (auto const* choice : choices) {
+        result.push_back(wxString::FromUTF8(choice));
+    }
+    return result;
+}
+
+template <size_t N>
+inline auto convertToUtf8(std::array<std::string, N> const& choices) -> std::vector<wxString>
+{
+    auto result = std::vector<wxString> {};
+    result.reserve(choices.size());
+    for (auto const& choice : choices) {
+        result.push_back(wxString::FromUTF8(choice));
+    }
+    return result;
+}
+
+inline auto convertToUtf8(std::vector<char const*> const& choices) -> std::vector<wxString>
+{
+    auto result = std::vector<wxString> {};
+    result.reserve(choices.size());
+    for (auto const* choice : choices) {
+        result.push_back(wxString::FromUTF8(choice));
+    }
+    return result;
+}
+
+inline auto flattenToUtf8(std::initializer_list<std::initializer_list<char const*>> choices) -> std::vector<wxString>
+{
+    auto count = static_cast<size_t>(0);
+    for (auto const& group : choices) {
+        count += group.size();
+    }
+    auto result = std::vector<wxString> {};
+    result.reserve(count);
+    for (auto const& group : choices) {
+        for (auto const* choice : group) {
+            result.push_back(wxString::FromUTF8(choice));
+        }
+    }
+    return result;
+}
+
 template <typename R, typename T>
 concept input_range_of = std::ranges::input_range<R> && std::convertible_to<std::ranges::range_value_t<R>, T>;
+
+template <typename R>
+concept utf8_text_input_range = std::ranges::input_range<R>
+    && (std::same_as<std::ranges::range_value_t<R>, wxString>
+        || std::same_as<std::ranges::range_value_t<R>, std::string>
+        || std::same_as<std::ranges::range_value_t<R>, std::string_view>
+        || std::same_as<std::ranges::range_value_t<R>, char const*>);
+
+template <utf8_text_input_range Range>
+inline auto ToVectorUtf8(Range&& range) -> std::vector<wxString>
+{
+    using value_t = std::ranges::range_value_t<Range>;
+    auto result = std::vector<wxString> {};
+    if constexpr (std::same_as<value_t, wxString>) {
+        std::ranges::copy(std::forward<Range>(range), std::back_inserter(result));
+    } else if constexpr (std::same_as<value_t, std::string>) {
+        std::ranges::transform(std::forward<Range>(range), std::back_inserter(result), [](auto const& choice) {
+            return wxString::FromUTF8(choice);
+        });
+    } else if constexpr (std::same_as<value_t, std::string_view>) {
+        std::ranges::transform(std::forward<Range>(range), std::back_inserter(result), [](auto const choice) {
+            return wxString::FromUTF8(std::string(choice));
+        });
+    } else {
+        std::ranges::transform(std::forward<Range>(range), std::back_inserter(result), [](auto const* choice) {
+            return wxString::FromUTF8(choice);
+        });
+    }
+    return result;
+}
 
 // This is due to missing support for ranges::to()
 template <typename T, std::ranges::range Range>

--- a/tests/wxUI_ChoiceTests.cpp
+++ b/tests/wxUI_ChoiceTests.cpp
@@ -46,6 +46,26 @@ static auto createUUT() { return ChoiceTestPolicy::createUUT(); }
 
 TEST_CASE("Choice")
 {
+    SECTION("compile test")
+    {
+        // This just confirms which of the forms of construction are correct.
+        TypeUnderTest {};
+        TypeUnderTest { "hi" };
+        TypeUnderTest { "hi", "bye" };
+        TypeUnderTest { "hi", "bye", "goodbye" };
+        // TypeUnderTest{{}};
+        // TypeUnderTest{{"hi"}};
+        TypeUnderTest { { "hi", "bye" } };
+        TypeUnderTest { { "hi", "bye", "goodbye" } };
+        TypeUnderTest();
+        // TypeUnderTest( "hi" );
+        // TypeUnderTest( "hi", "bye" );
+        // TypeUnderTest( "hi", "bye", "goodbye" );
+        // TypeUnderTest({});
+        TypeUnderTest({ "hi" });
+        TypeUnderTest({ "hi", "bye" });
+        TypeUnderTest({ "hi", "bye", "goodbye" });
+    }
     SECTION("noargs")
     {
         TestParent provider;
@@ -192,7 +212,7 @@ TEST_CASE("Choice")
     SECTION("AI")
     {
         TestParent provider;
-        auto uut = wxUI::Choice { { "one 🐨", "two", "three" } }.withSelection(1).bind([] {});
+        auto uut = wxUI::Choice { { "one 🐨", "two", "three" } }.withSelection(1).bind([] { });
         uut.create(&provider);
         CHECK(provider.dump() == std::vector<std::string> {
                   "Create:wxChoice[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"one 🐨\",\"two\",\"three\",)]",
@@ -200,6 +220,19 @@ TEST_CASE("Choice")
                   "SetSelection:1",
                   "SetEnabled:true",
                   "BindEvents:1",
+              });
+    }
+
+    SECTION("string.literals.nested.braces")
+    {
+        TestParent provider;
+        auto uut = wxUI::Choice { { "one 🐨", "two" } }.withSelection(1);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "Create:wxChoice[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"one 🐨\",\"two\",)]",
+                  "controller:wxChoice[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"one 🐨\",\"two\",)]",
+                  "SetSelection:1",
+                  "SetEnabled:true",
               });
     }
 

--- a/tests/wxUI_ListBoxTests.cpp
+++ b/tests/wxUI_ListBoxTests.cpp
@@ -45,6 +45,26 @@ static auto createUUT() { return ListBoxTestPolicy::createUUT(); }
 
 TEST_CASE("ListBox")
 {
+    SECTION("compile test")
+    {
+        // This just confirms which of the forms of construction are correct.
+        TypeUnderTest {};
+        TypeUnderTest { "hi" };
+        TypeUnderTest { "hi", "bye" };
+        TypeUnderTest { "hi", "bye", "goodbye" };
+        // TypeUnderTest{{}};
+        // TypeUnderTest{{"hi"}};
+        TypeUnderTest { { "hi", "bye" } };
+        TypeUnderTest { { "hi", "bye", "goodbye" } };
+        TypeUnderTest();
+        // TypeUnderTest( "hi" );
+        // TypeUnderTest( "hi", "bye" );
+        // TypeUnderTest( "hi", "bye", "goodbye" );
+        // TypeUnderTest({});
+        TypeUnderTest({ "hi" });
+        TypeUnderTest({ "hi", "bye" });
+        TypeUnderTest({ "hi", "bye", "goodbye" });
+    }
     SECTION("noargs")
     {
         TestParent provider;
@@ -101,6 +121,19 @@ TEST_CASE("ListBox")
         CHECK(provider.dump() == std::vector<std::string> {
                   "Create:wxListBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"Hello 🐨\",\"Goodbye\",)]",
                   "controller:wxListBox[id=10000, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"Hello 🐨\",\"Goodbye\",)]",
+                  "SetEnabled:true",
+              });
+    }
+
+    SECTION("string.literals.nested.braces")
+    {
+        TestParent provider;
+        auto uut = TypeUnderTest { { "one 🐨", "two" } }.withSelection(1);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "Create:wxListBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"one 🐨\",\"two\",)]",
+                  "controller:wxListBox[id=-1, pos=(-1,-1), size=(-1,-1), style=0, choices=(\"one 🐨\",\"two\",)]",
+                  "SetSelection:1",
                   "SetEnabled:true",
               });
     }

--- a/tests/wxUI_RadioBoxTests.cpp
+++ b/tests/wxUI_RadioBoxTests.cpp
@@ -25,6 +25,9 @@ SOFTWARE.
 #include <catch2/catch_test_macros.hpp>
 #include <wxUI/RadioBox.hpp>
 
+#include <array>
+#include <string_view>
+
 #include <wx/wx.h>
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)
@@ -45,6 +48,26 @@ static auto createUUT() { return RadioBoxTestPolicy::createUUT(); }
 
 TEST_CASE("RadioBox")
 {
+    SECTION("compile test")
+    {
+        // This just confirms which of the forms of construction are correct.
+        // TypeUnderTest { TypeUnderTest::withChoices {} };
+        TypeUnderTest { TypeUnderTest::withChoices {}, "hi" };
+        // TypeUnderTest { TypeUnderTest::withChoices {}, "hi", "bye" };
+        // TypeUnderTest { TypeUnderTest::withChoices {}, "hi", "bye", "goodbye" };
+        // TypeUnderTest { TypeUnderTest::withChoices {}, {} };
+        TypeUnderTest { TypeUnderTest::withChoices {}, { "hi" } };
+        TypeUnderTest { TypeUnderTest::withChoices {}, { "hi", "bye" } };
+        TypeUnderTest { TypeUnderTest::withChoices {}, { "hi", "bye", "goodbye" } };
+        // TypeUnderTest(TypeUnderTest::withChoices {});
+        TypeUnderTest(TypeUnderTest::withChoices {}, "hi");
+        // TypeUnderTest(TypeUnderTest::withChoices {}, "hi", "bye");
+        // TypeUnderTest(TypeUnderTest::withChoices {}, "hi", "bye", "goodbye");
+        // TypeUnderTest(TypeUnderTest::withChoices {}, {});
+        TypeUnderTest(TypeUnderTest::withChoices {}, { "hi" });
+        TypeUnderTest(TypeUnderTest::withChoices {}, { "hi", "bye" });
+        TypeUnderTest(TypeUnderTest::withChoices {}, { "hi", "bye", "goodbye" });
+    }
     SECTION("choices")
     {
         TestParent provider;
@@ -95,6 +118,72 @@ TEST_CASE("RadioBox")
                   "Create:wxRadioBox[id=10000, pos=(-1,-1), size=(-1,-1), style=4, text=\"Greetings\", choices=(\"Hello 🐨\",\"Goodbye\",), majorDim=0]",
                   "controller:wxRadioBox[id=10000, pos=(-1,-1), size=(-1,-1), style=4, text=\"Greetings\", choices=(\"Hello 🐨\",\"Goodbye\",), majorDim=0]",
                   "SetSelection:0",
+                  "SetEnabled:true",
+              });
+    }
+
+    SECTION("choices.single.literal")
+    {
+        TestParent provider;
+        auto uut = TypeUnderTest { TypeUnderTest::withChoices {}, "Hello 🐨" };
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "Create:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello 🐨\",), majorDim=0]",
+                  "controller:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello 🐨\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
+    }
+
+    SECTION("id.choices.single.literal")
+    {
+        TestParent provider;
+        auto uut = TypeUnderTest { 10000, TypeUnderTest::withChoices {}, "Hello 🐨" };
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "Create:wxRadioBox[id=10000, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello 🐨\",), majorDim=0]",
+                  "controller:wxRadioBox[id=10000, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello 🐨\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
+    }
+
+    SECTION("choices.initializer_list.string_view")
+    {
+        TestParent provider;
+        auto uut = TypeUnderTest { TypeUnderTest::withChoices {}, { std::string_view { "Hello 🐨" }, std::string_view { "Goodbye" } } };
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "Create:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello 🐨\",\"Goodbye\",), majorDim=0]",
+                  "controller:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello 🐨\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
+    }
+
+    SECTION("choices.ranges.array.string.literals")
+    {
+        TestParent provider;
+        auto const choices = std::array<char const*, 2> { "Hello 🐨", "Goodbye" };
+        auto uut = TypeUnderTest { TypeUnderTest::withChoices {}, choices };
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "Create:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello 🐨\",\"Goodbye\",), majorDim=0]",
+                  "controller:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello 🐨\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:0",
+                  "SetEnabled:true",
+              });
+    }
+
+    SECTION("choices.string.literals.nested.braces")
+    {
+        TestParent provider;
+        auto uut = TypeUnderTest { TypeUnderTest::withChoices {}, { { "Hello 🐨", "Goodbye" } } }.withSelection(1);
+        uut.create(&provider);
+        CHECK(provider.dump() == std::vector<std::string> {
+                  "Create:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello 🐨\",\"Goodbye\",), majorDim=0]",
+                  "controller:wxRadioBox[id=-1, pos=(-1,-1), size=(-1,-1), style=4, text=\"\", choices=(\"Hello 🐨\",\"Goodbye\",), majorDim=0]",
+                  "SetSelection:1",
                   "SetEnabled:true",
               });
     }


### PR DESCRIPTION
Removing undefined behavior of the conversion of { "a", "b" } to a string.

This also handles 'flattening' for overloads.  For example, all of these will now compile:

Flat overload:
ComboBox{"hi"}
ComboBox{"hi", "bye"}
Nested overload:
ComboBox{{"hi", "bye"}} // one inner group
ComboBox{{"a"}, {"b", "c"}} // multiple inner groups (flattened to a,b,c)