### PR TITLE
Issue #297: Make sure that mutable lambdas are usable in places that …

### DIFF
--- a/LATEST_RELEASE_NOTES.md
+++ b/LATEST_RELEASE_NOTES.md
@@ -5,6 +5,7 @@ Bugs addressed in this release:
 * [#255](../../issues/255) Missed some std::string that should be std::string_view
 * [#274](../../issues/274) ASAN failure with when using ComboBox { { hello, goodbye } }
 * [#279](../../issues/279) We have made it more difficult to use include dir
+* [#297](../../issues/297) Make sure that mutable lambdas are usable in places that take lambdas
 
 Other changes:
 

--- a/include/wxUI/Custom.hpp
+++ b/include/wxUI/Custom.hpp
@@ -38,9 +38,20 @@ concept CreateAndAddFunction = requires(T function, wxWindow* window, wxSizer* s
 
 template <CreateAndAddFunction Function>
 struct Custom {
+    Custom(wxSizerFlags const& flags, Function&& function)
+        : flags_(flags)
+        , function_(std::move(function))
+    {
+    }
+
     Custom(wxSizerFlags const& flags, Function const& function)
         : flags_(flags)
         , function_(function)
+    {
+    }
+
+    explicit Custom(Function&& function)
+        : function_(std::move(function))
     {
     }
 
@@ -49,7 +60,8 @@ struct Custom {
     {
     }
 
-    auto createAndAdd(wxWindow* parent, wxSizer* parentSizer, wxSizerFlags const& parentFlags)
+    template <typename Parent, typename Sizer>
+    auto createAndAdd(Parent* parent, Sizer* parentSizer, wxSizerFlags const& parentFlags)
     {
         function_(parent, parentSizer, flags_.value_or(parentFlags));
     }

--- a/include/wxUI/Widget.hpp
+++ b/include/wxUI/Widget.hpp
@@ -298,14 +298,14 @@ struct WidgetDetails {
 
     // Bind API (made public here so controllers can forward easily)
     template <typename Function, typename Event = wxCommandEvent>
-    auto bind(wxEventTypeTag<Event> event, Function function)
+    auto bind(wxEventTypeTag<Event> event, Function&& function)
     {
-        if constexpr (is_noarg_callable<Function>()) {
-            boundedFunctions_.emplace_back(event, [function = function](Event&) {
+        if constexpr (is_noarg_callable<std::decay_t<Function>>()) {
+            boundedFunctions_.emplace_back(event, [function = std::forward<Function>(function)](Event&) mutable {
                 function();
             });
         } else {
-            boundedFunctions_.emplace_back(event, function);
+            boundedFunctions_.emplace_back(event, std::forward<Function>(function));
         }
     }
 

--- a/include/wxUI/detail/BindInfo.hpp
+++ b/include/wxUI/detail/BindInfo.hpp
@@ -58,8 +58,8 @@ struct BindInfo {
     }
 
     template <typename Event, typename Function>
-    BindInfo(Event event, Function function)
-        : info_(std::make_unique<BindInfoDetails<Event, Function>>(event, function))
+    BindInfo(Event event, Function&& function)
+        : info_(std::make_unique<BindInfoDetails<Event, std::decay_t<Function>>>(event, std::forward<Function>(function)))
     {
     }
 
@@ -99,9 +99,10 @@ private:
 
     template <typename Event, typename Function>
     struct BindInfoDetails : BindInfoDetailsBase {
-        BindInfoDetails(Event event, Function function)
+        template <typename F>
+        BindInfoDetails(Event event, F&& function)
             : event(event)
-            , function(function)
+            , function(std::forward<F>(function))
         {
         }
         Event event;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(wxUI_Tests
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_CheckBoxTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_ChoiceTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_ComboBoxTests.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_CustomTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_FactoryTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_ForEachTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wxUI_GaugeTests.cpp

--- a/tests/wxUI_ButtonTests.cpp
+++ b/tests/wxUI_ButtonTests.cpp
@@ -24,7 +24,9 @@ SOFTWARE.
 #include "TestCustomizations.hpp"
 #include "wxUI_TestControlCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <wxUI/Button.hpp>
+#include <wxUI/Layout.hpp>
 #include <wxUI/wxUITypes.hpp>
 
 #include <wx/wx.h>
@@ -46,131 +48,171 @@ struct ButtonTestPolicy {
 };
 static auto createUUT() { return ButtonTestPolicy::createUUT(); }
 
-TEST_CASE("Button")
-{
-    SECTION("noargs")
-    {
+TEST_CASE("Button") {
+    SECTION("noargs") {
         TestParent provider;
-        auto uut = createUUT();
-        uut.create(&provider);
-        CHECK(provider.dump() == std::vector<std::string> {
-                  "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
-                  "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
-                  "SetEnabled:true",
-              });
-    }
-
-    SECTION("name")
-    {
-        TestParent provider;
-        auto uut = TypeUnderTest { "Hello" };
-        uut.create(&provider);
-        CHECK(provider.dump() == std::vector<std::string> {
-                  "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
-                  "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
-                  "SetEnabled:true",
-              });
-    }
-
-    SECTION("name_unicode")
-    {
-        TestParent provider;
-        auto uut = TypeUnderTest { "🐨" };
-        uut.create(&provider);
-        CHECK(provider.dump() == std::vector<std::string> {
-                  "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"🐨\"]",
-                  "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"🐨\"]",
-                  "SetEnabled:true",
-              });
-    }
-
-    SECTION("name_tag")
-    {
-        TestParent provider;
-        wxString wx_label { "Hello" };
-        auto uut = TypeUnderTest { wxUI_String {}, wx_label };
-        uut.create(&provider);
-        CHECK(provider.dump() == std::vector<std::string> {
-                  "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
-                  "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
-                  "SetEnabled:true",
-              });
-    }
-
-    SECTION("id")
-    {
-        TestParent provider;
-        auto uut = TypeUnderTest { 10000 };
-        uut.create(&provider);
-        CHECK(provider.dump() == std::vector<std::string> {
-                  "Create:wxButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
-                  "controller:wxButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
-                  "SetEnabled:true",
-              });
-    }
-
-    SECTION("id.name")
-    {
-        TestParent provider;
-        auto uut = TypeUnderTest { 10000, "Hello" };
-        uut.create(&provider);
-        CHECK(provider.dump() == std::vector<std::string> {
-                  "Create:wxButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
-                  "controller:wxButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
-                  "SetEnabled:true",
-              });
-    }
-
-    SECTION("style")
-    {
-        TestParent provider;
-        auto uut = createUUT().withStyle(wxBU_LEFT);
-        uut.create(&provider);
-        CHECK(provider.dump() == std::vector<std::string> {
-                  "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=64, text=\"\"]",
-                  "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=64, text=\"\"]",
-                  "SetEnabled:true",
-              });
-    }
-
-    SECTION("pos")
-    {
-        TestParent provider;
-        auto uut = createUUT().withPosition({ 1, 2 });
-        uut.create(&provider);
-        CHECK(provider.dump() == std::vector<std::string> {
-                  "Create:wxButton[id=-1, pos=(1,2), size=(-1,-1), style=0, text=\"\"]",
-                  "controller:wxButton[id=-1, pos=(1,2), size=(-1,-1), style=0, text=\"\"]",
-                  "SetEnabled:true",
-              });
-    }
-
-    SECTION("size")
-    {
-        TestParent provider;
-        auto uut = createUUT().withSize({ 1, 2 });
-        uut.create(&provider);
-        CHECK(provider.dump() == std::vector<std::string> {
-                  "Create:wxButton[id=-1, pos=(-1,-1), size=(1,2), style=0, text=\"\"]",
-                  "controller:wxButton[id=-1, pos=(-1,-1), size=(1,2), style=0, text=\"\"]",
-                  "SetEnabled:true",
-              });
-    }
-
-    SECTION("AI Gen")
-    {
-        TestParent provider;
-        auto uut = wxUI::Button { "Hello" }.withStyle(wxBU_LEFT).withPosition({ 1, 2 }).withSize({ 10, 12 }).setDefault().bind([] {});
-        uut.create(&provider);
-        CHECK(provider.dump() == std::vector<std::string> {
-                  "Create:wxButton[id=-1, pos=(1,2), size=(10,12), style=64, text=\"Hello\"]",
-                  "controller:wxButton[id=-1, pos=(1,2), size=(10,12), style=64, text=\"Hello\"]",
-                  "SetDefault:-1",
-                  "SetEnabled:true",
-                  "BindEvents:1",
-              });
-    }
-
-    COMMON_TESTS(ButtonTestPolicy)
+auto uut = createUUT();
+uut.create(&provider);
+CHECK(provider.dump() == std::vector<std::string> {
+          "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+          "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+          "SetEnabled:true",
+      });
 }
+
+SECTION("name")
+{
+    TestParent provider;
+    auto uut = TypeUnderTest { "Hello" };
+    uut.create(&provider);
+    CHECK(provider.dump() == std::vector<std::string> {
+              "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+              "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+              "SetEnabled:true",
+          });
+}
+
+SECTION("name_unicode")
+{
+    TestParent provider;
+    auto uut = TypeUnderTest { "🐨" };
+    uut.create(&provider);
+    CHECK(provider.dump() == std::vector<std::string> {
+              "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"🐨\"]",
+              "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"🐨\"]",
+              "SetEnabled:true",
+          });
+}
+
+SECTION("name_tag")
+{
+    TestParent provider;
+    wxString wx_label { "Hello" };
+    auto uut = TypeUnderTest { wxUI_String {}, wx_label };
+    uut.create(&provider);
+    CHECK(provider.dump() == std::vector<std::string> {
+              "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+              "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+              "SetEnabled:true",
+          });
+}
+
+SECTION("id")
+{
+    TestParent provider;
+    auto uut = TypeUnderTest { 10000 };
+    uut.create(&provider);
+    CHECK(provider.dump() == std::vector<std::string> {
+              "Create:wxButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+              "controller:wxButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"\"]",
+              "SetEnabled:true",
+          });
+}
+
+SECTION("id.name")
+{
+    TestParent provider;
+    auto uut = TypeUnderTest { 10000, "Hello" };
+    uut.create(&provider);
+    CHECK(provider.dump() == std::vector<std::string> {
+              "Create:wxButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+              "controller:wxButton[id=10000, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
+              "SetEnabled:true",
+          });
+}
+
+SECTION("style")
+{
+    TestParent provider;
+    auto uut = createUUT().withStyle(wxBU_LEFT);
+    uut.create(&provider);
+    CHECK(provider.dump() == std::vector<std::string> {
+              "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=64, text=\"\"]",
+              "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=64, text=\"\"]",
+              "SetEnabled:true",
+          });
+}
+
+SECTION("pos")
+{
+    TestParent provider;
+    auto uut = createUUT().withPosition({ 1, 2 });
+    uut.create(&provider);
+    CHECK(provider.dump() == std::vector<std::string> {
+              "Create:wxButton[id=-1, pos=(1,2), size=(-1,-1), style=0, text=\"\"]",
+              "controller:wxButton[id=-1, pos=(1,2), size=(-1,-1), style=0, text=\"\"]",
+              "SetEnabled:true",
+          });
+}
+
+SECTION("size")
+{
+    TestParent provider;
+    auto uut = createUUT().withSize({ 1, 2 });
+    uut.create(&provider);
+    CHECK(provider.dump() == std::vector<std::string> {
+              "Create:wxButton[id=-1, pos=(-1,-1), size=(1,2), style=0, text=\"\"]",
+              "controller:wxButton[id=-1, pos=(-1,-1), size=(1,2), style=0, text=\"\"]",
+              "SetEnabled:true",
+          });
+}
+
+SECTION("AI Gen")
+{
+    TestParent provider;
+    auto uut = wxUI::Button { "Hello" }.withStyle(wxBU_LEFT).withPosition({ 1, 2 }).withSize({ 10, 12 }).setDefault().bind([] { });
+    uut.create(&provider);
+    CHECK(provider.dump() == std::vector<std::string> {
+              "Create:wxButton[id=-1, pos=(1,2), size=(10,12), style=64, text=\"Hello\"]",
+              "controller:wxButton[id=-1, pos=(1,2), size=(10,12), style=64, text=\"Hello\"]",
+              "SetDefault:-1",
+              "SetEnabled:true",
+              "BindEvents:1",
+          });
+}
+
+COMMON_TESTS(ButtonTestPolicy)
+}
+
+TEST_CASE("Button - Mutable lambda in bind")
+{
+    TestParent provider;
+
+    SECTION("Button.bind with mutable lambda (no-arg)")
+    {
+        int counter = 0;
+
+        wxUI::VSizer {
+            wxUI::Button { "Click" }.bind([counter]() mutable {
+                counter++;
+                // Note: This will be called when the button is clicked
+                // For testing purposes, we just verify it compiles and stores correctly
+            })
+        }
+            .fitTo(&provider);
+
+        auto dump = provider.dump();
+        CHECK(dump.size() > 0);
+    }
+
+    SECTION("Button.bind with mutable lambda (with event)")
+    {
+        int value = 10;
+
+        wxUI::VSizer {
+            wxUI::Button { "Click" }.bind([value](wxCommandEvent&) mutable {
+                value += 5;
+            })
+        }
+            .fitTo(&provider);
+
+        auto dump = provider.dump();
+        CHECK(dump.size() > 0);
+    }
+}
+
+// Note: Move-only lambdas (capturing unique_ptr) cannot be used with bind()
+// because wxWidgets' event system requires event handlers to be copyable.
+// BindInfo must support copying via clone(), which is incompatible with move-only types.
+
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity, misc-use-anonymous-namespace, cppcoreguidelines-avoid-do-while)

--- a/tests/wxUI_CustomTests.cpp
+++ b/tests/wxUI_CustomTests.cpp
@@ -1,0 +1,176 @@
+/*
+MIT License
+
+Copyright (c) 2022-2026 Richard Powell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#include "TestCustomizations.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <wx/button.h>
+#include <wxUI/Custom.hpp>
+#include <wxUI/Layout.hpp>
+
+#include <wx/wx.h>
+
+using namespace wxUITests;
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)
+
+TEST_CASE("Custom")
+{
+    TestParent provider;
+
+    SECTION("Custom with simple lambda")
+    {
+        bool called = false;
+        wxUI::VSizer {
+            wxUI::Custom {
+                [&called](auto* /*parent*/, auto* /*sizer*/, auto const& /*flags*/) {
+                    called = true;
+                } }
+        }
+            .fitTo(&provider);
+
+        CHECK(called);
+    }
+
+    SECTION("Custom with flags")
+    {
+        bool called = false;
+        wxUI::VSizer {
+            wxUI::Custom {
+                wxSizerFlags(1),
+                [&called](auto* /*parent*/, auto* /*sizer*/, auto const& /*flags*/) {
+                    called = true;
+                } }
+        }
+            .fitTo(&provider);
+
+        CHECK(called);
+    }
+}
+
+TEST_CASE("Custom - Move-only lambda support")
+{
+    TestParent provider;
+
+    SECTION("Custom with move-only lambda (unique_ptr capture)")
+    {
+        auto resource = std::make_unique<int>(42);
+        bool called = false;
+
+        wxUI::VSizer {
+            wxUI::Custom {
+                [resource = std::move(resource), &called](auto* /*parent*/, auto* /*sizer*/, auto const& /*flags*/) mutable {
+                    // Verify we have the resource
+                    CHECK(resource != nullptr);
+                    CHECK(*resource == 42);
+                    called = true;
+                } }
+        }
+            .fitTo(&provider);
+
+        CHECK(called);
+    }
+
+    SECTION("Custom with flags and move-only lambda")
+    {
+        auto resource = std::make_unique<std::string>("test");
+        bool called = false;
+
+        wxUI::VSizer {
+            wxUI::Custom {
+                wxSizerFlags(1),
+                [resource = std::move(resource), &called](auto* /*parent*/, auto* /*sizer*/, auto const& /*flags*/) mutable {
+                    CHECK(resource != nullptr);
+                    CHECK(*resource == "test");
+                    called = true;
+                } }
+        }
+            .fitTo(&provider);
+
+        CHECK(called);
+    }
+}
+
+TEST_CASE("Custom - Mutable lambda support")
+{
+    TestParent provider;
+
+    SECTION("Custom with mutable lambda")
+    {
+        int callCount = 0;
+
+        wxUI::VSizer {
+            wxUI::Custom {
+                [callCount](auto* /*parent*/, auto* /*sizer*/, auto const& /*flags*/) mutable {
+                    callCount++;
+                    CHECK(callCount == 1);
+                } }
+        }
+            .fitTo(&provider);
+    }
+
+    SECTION("Custom with flags and mutable lambda")
+    {
+        int value = 10;
+        bool called = false;
+
+        wxUI::VSizer {
+            wxUI::Custom {
+                wxSizerFlags(1),
+                [value, &called](auto* /*parent*/, auto* /*sizer*/, auto const& /*flags*/) mutable {
+                    value += 5;
+                    CHECK(value == 15);
+                    called = true;
+                } }
+        }
+            .fitTo(&provider);
+
+        CHECK(called);
+    }
+}
+
+TEST_CASE("Custom - Lambda with mutable captured unique_ptr")
+{
+    TestParent provider;
+
+    SECTION("Move-only mutable lambda")
+    {
+        auto data = std::make_unique<int>(100);
+        bool called = false;
+
+        wxUI::VSizer {
+            wxUI::Custom {
+                [data = std::move(data), &called](auto* /*parent*/, auto* /*sizer*/, auto const& /*flags*/) mutable {
+                    CHECK(data != nullptr);
+                    *data += 50;
+                    CHECK(*data == 150);
+                    called = true;
+                } }
+        }
+            .fitTo(&provider);
+
+        CHECK(called);
+    }
+}
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)

--- a/tests/wxUI_FactoryTests.cpp
+++ b/tests/wxUI_FactoryTests.cpp
@@ -23,6 +23,7 @@ SOFTWARE.
 */
 #include "TestCustomizations.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <wx/button.h>
 #include <wxUI/Factory.hpp>
 #include <wxUI/Layout.hpp>
@@ -69,6 +70,90 @@ TEST_CASE("Factory")
                   "Add:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Factory\"]:flags:(1,0x0,0)",
                   "SetSizeHints:[id=0, pos=(0,0), size=(0,0), style=0]",
               });
+    }
+}
+
+TEST_CASE("Factory - Move-only lambda support")
+{
+    TestParent provider;
+
+    SECTION("Factory with move-only lambda (unique_ptr capture)")
+    {
+        auto resource = std::make_unique<std::string>("test");
+
+        wxUI::VSizer {
+            wxUI::Factory {
+                [resource = std::move(resource)](auto* parent) {
+                    CHECK(resource != nullptr);
+                    CHECK(*resource == "test");
+                    return wxUI::customizations::ParentCreate<wxButton>(parent, wxID_ANY, std::string { "Factory" }, wxDefaultPosition, wxDefaultSize, int64_t {});
+                } }
+        }
+            .fitTo(&provider);
+
+        auto dump = provider.dump();
+        CHECK(dump.size() > 0);
+    }
+
+    SECTION("Factory with flags and move-only lambda")
+    {
+        auto data = std::make_unique<int>(42);
+
+        wxUI::VSizer {
+            wxUI::Factory {
+                wxSizerFlags(1),
+                [data = std::move(data)](auto* parent) {
+                    CHECK(data != nullptr);
+                    CHECK(*data == 42);
+                    return wxUI::customizations::ParentCreate<wxButton>(parent, wxID_ANY, std::string { "Factory" }, wxDefaultPosition, wxDefaultSize, int64_t {});
+                } }
+        }
+            .fitTo(&provider);
+
+        auto dump = provider.dump();
+        CHECK(dump.size() > 0);
+    }
+}
+
+TEST_CASE("Factory - Mutable lambda support")
+{
+    TestParent provider;
+
+    SECTION("Factory with mutable lambda")
+    {
+        int counter = 0;
+
+        wxUI::VSizer {
+            wxUI::Factory {
+                [counter](auto* parent) mutable {
+                    counter++;
+                    CHECK(counter == 1);
+                    return wxUI::customizations::ParentCreate<wxButton>(parent, wxID_ANY, std::string { "Factory" }, wxDefaultPosition, wxDefaultSize, int64_t {});
+                } }
+        }
+            .fitTo(&provider);
+
+        auto dump = provider.dump();
+        CHECK(dump.size() > 0);
+    }
+
+    SECTION("Factory with move-only mutable lambda")
+    {
+        auto value = std::make_unique<int>(10);
+
+        wxUI::VSizer {
+            wxUI::Factory {
+                [value = std::move(value)](auto* parent) mutable {
+                    CHECK(value != nullptr);
+                    *value += 5;
+                    CHECK(*value == 15);
+                    return wxUI::customizations::ParentCreate<wxButton>(parent, wxID_ANY, std::string { "Factory" }, wxDefaultPosition, wxDefaultSize, int64_t {});
+                } }
+        }
+            .fitTo(&provider);
+
+        auto dump = provider.dump();
+        CHECK(dump.size() > 0);
     }
 }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)

--- a/tests/wxUI_ForEachTests.cpp
+++ b/tests/wxUI_ForEachTests.cpp
@@ -23,6 +23,7 @@ SOFTWARE.
 */
 #include "TestCustomizations.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <ranges>
 #include <wxUI/Button.hpp>
 #include <wxUI/ForEach.hpp>
@@ -1247,6 +1248,92 @@ TEST_CASE("ForEach")
                 .fitTo(&frame);
             CHECK(frame.dump() == kCaseHForEachWithID);
         }
+    }
+}
+
+TEST_CASE("ForEach - Move-only lambda support")
+{
+    TestParent provider;
+
+    SECTION("ForEach with move-only lambda (unique_ptr capture)")
+    {
+        auto resource = std::make_unique<int>(42);
+
+        wxUI::VForEach({ "A", "B", "C" }, [resource = std::move(resource)](auto const& name) {
+            CHECK(resource != nullptr);
+            CHECK(*resource == 42);
+            return wxUI::Button { name };
+        }).fitTo(&provider);
+
+        auto dump = provider.dump();
+        CHECK(dump.size() > 0);
+    }
+
+    SECTION("HForEach with move-only lambda")
+    {
+        auto data = std::make_unique<std::string>("test");
+
+        wxUI::HForEach({ "X", "Y" }, [data = std::move(data)](auto const& name) {
+            CHECK(data != nullptr);
+            CHECK(*data == "test");
+            return wxUI::Button { name };
+        }).fitTo(&provider);
+
+        auto dump = provider.dump();
+        CHECK(dump.size() > 0);
+    }
+}
+
+TEST_CASE("ForEach - Mutable lambda support")
+{
+    TestParent provider;
+
+    SECTION("VForEach with mutable lambda")
+    {
+        int counter = 0;
+
+        wxUI::VForEach({ "A", "B", "C" }, [counter](auto const& name) mutable {
+            counter++;
+            CHECK(counter <= 3);
+            return wxUI::Button { name };
+        }).fitTo(&provider);
+
+        auto dump = provider.dump();
+        CHECK(dump.size() > 0);
+    }
+
+    SECTION("HForEach with mutable lambda modifying captured state")
+    {
+        int value = 0;
+
+        wxUI::HForEach({ "X", "Y" }, [value](auto const& name) mutable {
+            value += 10;
+            CHECK(value <= 20);
+            return wxUI::Button { name };
+        }).fitTo(&provider);
+
+        auto dump = provider.dump();
+        CHECK(dump.size() > 0);
+    }
+}
+
+TEST_CASE("ForEach - Move-only mutable lambda")
+{
+    TestParent provider;
+
+    SECTION("ForEach with move-only mutable lambda")
+    {
+        auto counter = std::make_unique<int>(0);
+
+        wxUI::VForEach({ "A", "B" }, [counter = std::move(counter)](auto const& name) mutable {
+            CHECK(counter != nullptr);
+            (*counter)++;
+            CHECK(*counter <= 2);
+            return wxUI::Button { name };
+        }).fitTo(&provider);
+
+        auto dump = provider.dump();
+        CHECK(dump.size() > 0);
     }
 }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)


### PR DESCRIPTION
…take lambdas

Add support for move-only and mutable lambdas

Enable perfect forwarding in Custom, BindInfo, and Widget::bind() to support move-only lambdas (e.g., unique_ptr captures) and mutable lambdas across Custom, Factory, and ForEach. Add comprehensive tests for all scenarios.

Note: bind() supports mutable lambdas but not move-only due to wxWidgets event system requiring copyable handlers.