### PR TITLE
Issue #304: Need a way to tests menu without instantiating wxMenu

### DIFF
--- a/LATEST_RELEASE_NOTES.md
+++ b/LATEST_RELEASE_NOTES.md
@@ -24,4 +24,5 @@ Other changes:
 * [#292](../../issues/292) FlexGridSizer does not support growable columns and will never increase to fill space
 * [#295](../../issues/295) make sure all files have a BuildTests
 * [#302](../../issues/302) Need better defaults for WXUI_WITH_TESTS, WXUI_WITH_EXAMPLE
+* [#304](../../issues/304) Need a way to tests menu without instantiating wxMenu
 

--- a/include/wxUI/Customizations.hpp
+++ b/include/wxUI/Customizations.hpp
@@ -25,9 +25,9 @@ SOFTWARE.
 
 #include <functional>
 #include <optional>
+#include <tuple>
 #include <variant>
 #include <vector>
-#include <tuple>
 #include <wx/frame.h>
 #include <wx/menu.h>
 #include <wx/sizer.h>
@@ -162,6 +162,65 @@ inline void SizerBindProxy(Sizer* sizer, Proxy& proxyHandle)
         proxyHandle.setUnderlying(sizer);
     } else {
         static_assert(always_false_v<Proxy>, "LayoutBindProxy: Provide a customization in namespace wxUI::customizations.");
+    }
+}
+
+// Menu creation customization points
+// These allow tests to avoid creating real wxMenu/wxMenuBar objects
+
+// Trait to get MenuItem type for a given Frame type
+template <typename Frame>
+struct MenuItemTypeFor {
+    using type = wxMenuItem;
+};
+
+template <typename Frame>
+using MenuItemTypeFor_t = typename MenuItemTypeFor<Frame>::type;
+
+template <typename Frame>
+inline auto MenuCreate(Frame&)
+{
+    return new wxMenu();
+}
+
+template <typename Frame>
+inline auto MenuBarCreate(Frame*)
+{
+    return new wxMenuBar();
+}
+
+inline auto MenuAppend(wxMenu* menu, int id, wxString const& item, wxString const& help) -> wxMenuItem*
+{
+    return menu->Append(id, item, help);
+}
+
+inline auto MenuAppendCheckItem(wxMenu* menu, int id, wxString const& item, wxString const& help) -> wxMenuItem*
+{
+    return menu->AppendCheckItem(id, item, help);
+}
+
+inline auto MenuAppendRadioItem(wxMenu* menu, int id, wxString const& item, wxString const& help) -> wxMenuItem*
+{
+    return menu->AppendRadioItem(id, item, help);
+}
+
+inline void MenuBarAppend(wxMenuBar* menuBar, wxMenu* menu, wxString const& name)
+{
+    menuBar->Append(menu, name);
+}
+
+inline void MenuAppendSubMenu(wxMenu* parentMenu, wxMenu* subMenu, wxString const& name)
+{
+    parentMenu->AppendSubMenu(subMenu, name);
+}
+
+template <typename Controller, typename Proxy>
+inline void MenuBindProxy(Controller* controller, Proxy& proxyHandle)
+{
+    if constexpr (requires(Proxy proxy, Controller* c) { proxy.setUnderlying(c); }) {
+        proxyHandle.setUnderlying(controller);
+    } else {
+        static_assert(always_false_v<Proxy>, "MenuBindProxy: Provide a customization in namespace wxUI::customizations.");
     }
 }
 

--- a/include/wxUI/Menu.hpp
+++ b/include/wxUI/Menu.hpp
@@ -36,14 +36,20 @@ SOFTWARE.
 
 namespace wxUI::details {
 
+// Tag types for disambiguating Menu::createAndAdd overloads
+struct ToMenuBarTag { };
+struct ToMenuTag { };
+
 template <typename T>
-concept MenuBarItem = requires(T widget, wxFrame frame, wxMenuBar menu, int identity) {
-    widget.createAndAdd(frame, menu, identity);
+concept MenuBarItem = requires(T widget, ToMenuBarTag tag, wxFrame frame, wxMenuBar menu, int identity) {
+    widget.createAndAdd(tag, frame, menu, identity);
 };
 
 template <typename T>
 concept MenuItem = requires(T widget, wxFrame frame, wxMenu menu, int identity) {
     widget.createAndAdd(frame, menu, identity);
+} || requires(T widget, ToMenuTag tag, wxFrame frame, wxMenu menu, int identity) {
+    widget.createAndAdd(tag, frame, menu, identity);
 };
 
 template <typename F, typename Arg>
@@ -168,18 +174,27 @@ struct Item {
         return std::move(*this);
     }
 
-    template <typename Frame>
-    void createAndAdd(Frame& frame, wxMenu& menu, int& identity)
+    template <typename Frame, typename MenuT>
+    void createAndAdd(Frame& frame, MenuT& menu, int& identity)
     {
         details::createAndAdd(frame, menuDetails_, identity, [this, &menu](int identity, wxString const& item, wxString const& help) {
-            auto* menuItem = menu.Append(identity, item, help);
-            for (auto& proxyHandle : proxyHandles_) {
-                proxyHandle.setUnderlying(menuItem);
-            }
+            using ::wxUI::customizations::MenuAppend;
+            auto* menuItem = MenuAppend(&menu, identity, item, help);
+            bindProxy(menuItem);
         });
     }
 
 private:
+    template <typename MenuT>
+    auto bindProxy(MenuT* widget)
+    {
+        for (auto& proxyHandle : proxyHandles_) {
+            using ::wxUI::customizations::MenuBindProxy;
+            MenuBindProxy(widget, proxyHandle);
+        }
+        return widget;
+    }
+
     details::MenuDetails menuDetails_;
     std::vector<MenuItemProxy> proxyHandles_;
 };
@@ -252,18 +267,27 @@ struct CheckItem {
         return std::move(*this);
     }
 
-    template <typename Frame>
-    void createAndAdd(Frame& frame, wxMenu& menu, int& identity)
+    template <typename Frame, typename MenuT>
+    void createAndAdd(Frame& frame, MenuT& menu, int& identity)
     {
         details::createAndAdd(frame, menuDetails_, identity, [this, &menu](int identity, wxString const& item, wxString const& help) {
-            auto* menuItem = menu.AppendCheckItem(identity, item, help);
-            for (auto& proxyHandle : proxyHandles_) {
-                proxyHandle.setUnderlying(menuItem);
-            }
+            using ::wxUI::customizations::MenuAppendCheckItem;
+            auto* menuItem = MenuAppendCheckItem(&menu, identity, item, help);
+            bindProxy(menuItem);
         });
     }
 
 private:
+    template <typename MenuT>
+    auto bindProxy(MenuT* widget)
+    {
+        for (auto& proxyHandle : proxyHandles_) {
+            using ::wxUI::customizations::MenuBindProxy;
+            MenuBindProxy(widget, proxyHandle);
+        }
+        return widget;
+    }
+
     details::MenuDetails menuDetails_;
     std::vector<MenuItemProxy> proxyHandles_;
 };
@@ -336,25 +360,34 @@ struct RadioItem {
         return std::move(*this);
     }
 
-    template <typename Frame>
-    void createAndAdd(Frame& frame, wxMenu& menu, int& identity)
+    template <typename Frame, typename MenuT>
+    void createAndAdd(Frame& frame, MenuT& menu, int& identity)
     {
         details::createAndAdd(frame, menuDetails_, identity, [this, &menu](int identity, wxString const& item, wxString const& help) {
-            auto* menuItem = menu.AppendRadioItem(identity, item, help);
-            for (auto& proxyHandle : proxyHandles_) {
-                proxyHandle.setUnderlying(menuItem);
-            }
+            using ::wxUI::customizations::MenuAppendRadioItem;
+            auto* menuItem = MenuAppendRadioItem(&menu, identity, item, help);
+            bindProxy(menuItem);
         });
     }
 
 private:
+    template <typename MenuT>
+    auto bindProxy(MenuT* widget)
+    {
+        for (auto& proxyHandle : proxyHandles_) {
+            using ::wxUI::customizations::MenuBindProxy;
+            MenuBindProxy(widget, proxyHandle);
+        }
+        return widget;
+    }
+
     details::MenuDetails menuDetails_;
     std::vector<MenuItemProxy> proxyHandles_;
 };
 
 struct Separator {
-    template <typename Frame>
-    static void createAndAdd(Frame&, wxMenu& menu, int&)
+    template <typename Frame, typename MenuT>
+    static void createAndAdd(Frame&, MenuT& menu, int&)
     {
         menu.AppendSeparator();
     }
@@ -369,8 +402,8 @@ struct MenuForEach {
     {
     }
 
-    template <typename Frame>
-    void createAndAdd(Frame& frame, wxMenu& menu, int& identity)
+    template <typename Frame, typename MenuT>
+    void createAndAdd(Frame& frame, MenuT& menu, int& identity)
     {
         using RawArg = std::remove_cvref_t<std::ranges::range_value_t<Range>>;
         for (auto&& item : args_) {
@@ -423,35 +456,52 @@ struct Menu {
         return std::move(*this);
     }
 
-    template <typename Frame>
-    void createAndAdd(Frame& frame, wxMenuBar& menuBar, int& identity)
+    template <typename Frame, typename MenuBarT>
+    void createAndAdd(details::ToMenuBarTag, Frame& frame, MenuBarT& menuBar, int& identity)
     {
-        auto menu = std::make_unique<wxMenu>();
-        std::apply([&frame, menu = menu.get(), &identity](auto&&... tupleArg) {
+        using ::wxUI::customizations::MenuBarAppend;
+        using ::wxUI::customizations::MenuCreate;
+        auto menu = MenuCreate(frame);
+        std::apply([&frame, menu, &identity](auto&&... tupleArg) {
             (tupleArg.createAndAdd(frame, *menu, identity), ...);
         },
             items);
-        for (auto& proxyHandle : proxyHandles_) {
-            proxyHandle.setUnderlying(menu.get());
-        }
-        menuBar.Append(menu.release(), name);
+        bindProxy(menu);
+        MenuBarAppend(&menuBar, menu, name);
     }
 
-    template <typename Frame>
-    void createAndAdd(Frame& frame, wxMenu& menu, int& identity)
+    template <typename Frame, typename MenuT>
+    void createAndAdd(details::ToMenuTag, Frame& frame, MenuT& menu, int& identity)
     {
-        auto subMenu = std::make_unique<wxMenu>();
-        std::apply([&frame, subMenu = subMenu.get(), &identity](auto&&... tupleArg) {
+        using ::wxUI::customizations::MenuAppendSubMenu;
+        using ::wxUI::customizations::MenuCreate;
+        auto subMenu = MenuCreate(frame);
+        std::apply([&frame, subMenu, &identity](auto&&... tupleArg) {
             (tupleArg.createAndAdd(frame, *subMenu, identity), ...);
         },
             items);
-        for (auto& proxyHandle : proxyHandles_) {
-            proxyHandle.setUnderlying(subMenu.get());
-        }
-        menu.AppendSubMenu(subMenu.release(), name);
+        bindProxy(subMenu);
+        MenuAppendSubMenu(&menu, subMenu, name);
+    }
+
+    // MenuItem concept-satisfying method: when Menu is used as a menu item (submenu)
+    template <typename Frame, typename MenuT>
+    void createAndAdd(Frame& frame, MenuT& menu, int& identity)
+    {
+        createAndAdd(details::ToMenuTag {}, frame, menu, identity);
     }
 
 private:
+    template <typename MenuT>
+    auto bindProxy(MenuT* widget)
+    {
+        for (auto& proxyHandle : proxyHandles_) {
+            using ::wxUI::customizations::MenuBindProxy;
+            MenuBindProxy(widget, proxyHandle);
+        }
+        return widget;
+    }
+
     wxString name;
     std::tuple<M...> items;
     std::vector<MenuProxy> proxyHandles_;
@@ -483,21 +533,30 @@ struct MenuBar {
     template <typename Frame>
     auto fitTo(Frame* frame) -> auto&
     {
+        using ::wxUI::customizations::MenuBarCreate;
+        using ::wxUI::customizations::MenuSetMenuBar;
         auto numbering = int(wxID_AUTO_LOWEST);
-        auto menuBar = std::make_unique<wxMenuBar>();
-        std::apply([frame, menuBar = menuBar.get(), &numbering](auto&&... tupleArg) {
-            (tupleArg.createAndAdd(*frame, *menuBar, numbering), ...);
+        auto menuBar = MenuBarCreate(frame);
+        std::apply([frame, menuBar, &numbering](auto&&... tupleArg) {
+            (tupleArg.createAndAdd(details::ToMenuBarTag {}, *frame, *menuBar, numbering), ...);
         },
             menus);
-        for (auto& proxyHandle : proxyHandles_) {
-            proxyHandle.setUnderlying(menuBar.get());
-        }
-        using ::wxUI::customizations::MenuSetMenuBar;
-        MenuSetMenuBar(frame, menuBar.release());
+        bindProxy(menuBar);
+        MenuSetMenuBar(frame, menuBar);
         return *this;
     }
 
 private:
+    template <typename MenuT>
+    auto bindProxy(MenuT* widget)
+    {
+        for (auto& proxyHandle : proxyHandles_) {
+            using ::wxUI::customizations::MenuBindProxy;
+            MenuBindProxy(widget, proxyHandle);
+        }
+        return widget;
+    }
+
     std::tuple<M...> menus;
     std::vector<MenuBarProxy> proxyHandles_;
 };

--- a/tests/TestCustomizations.hpp
+++ b/tests/TestCustomizations.hpp
@@ -49,6 +49,7 @@ SOFTWARE.
 #include <wx/statbmp.h>
 #include <wx/statline.h>
 #include <wx/stattext.h>
+#include <wx/stockitem.h>
 #include <wx/textctrl.h>
 #include <wx/tglbtn.h>
 #include <wxUI/Customizations.hpp>
@@ -162,6 +163,79 @@ struct std::formatter<wxMenuBar, char> {
 
 namespace wxUITests {
 
+// Mock menu structures to avoid creating real wxMenu/wxMenuBar objects in tests
+struct TestMenuItem {
+    int id {};
+    std::string kind; // "normal", "check", "radio"
+    std::string label;
+    std::string help;
+    int numProxyHandles { 0 };
+};
+
+struct TestMenu {
+    std::string title;
+    std::vector<TestMenuItem> items;
+    int numProxyHandles { 0 };
+};
+
+struct TestMenuBar {
+    std::vector<TestMenu> menus;
+    int numProxyHandles { 0 };
+};
+
+}
+
+// Formatters for test mock menu structures
+template <>
+struct std::formatter<wxUITests::TestMenuItem, char> {
+    constexpr auto parse(std::format_parse_context& ctx) { return ctx.begin(); }
+    auto format(wxUITests::TestMenuItem const& item, std::format_context& ctx) const
+    {
+        std::format_to(ctx.out(), "(menuItem:id={},kind={},label=\"{}\",help=\"{}\")",
+            item.id, item.kind, item.label, item.help);
+        if (item.numProxyHandles > 0) {
+            std::format_to(ctx.out(), ":numProxyHandles={}", item.numProxyHandles);
+        }
+        return ctx.out();
+    }
+};
+
+template <>
+struct std::formatter<wxUITests::TestMenu, char> {
+    constexpr auto parse(std::format_parse_context& ctx) { return ctx.begin(); }
+    auto format(wxUITests::TestMenu const& menu, std::format_context& ctx) const
+    {
+        std::format_to(ctx.out(), "[title:{}:[", menu.title);
+        for (auto const& item : menu.items) {
+            std::format_to(ctx.out(), "{},", item);
+        }
+        std::format_to(ctx.out(), "]");
+        if (menu.numProxyHandles > 0) {
+            std::format_to(ctx.out(), ":numProxyHandles={}", menu.numProxyHandles);
+        }
+        return ctx.out();
+    }
+};
+
+template <>
+struct std::formatter<wxUITests::TestMenuBar, char> {
+    constexpr auto parse(std::format_parse_context& ctx) { return ctx.begin(); }
+    auto format(wxUITests::TestMenuBar const& bar, std::format_context& ctx) const
+    {
+        std::format_to(ctx.out(), "[");
+        for (auto const& menu : bar.menus) {
+            std::format_to(ctx.out(), "{},", menu);
+        }
+        std::format_to(ctx.out(), "]");
+        if (bar.numProxyHandles > 0) {
+            std::format_to(ctx.out(), ":numProxyHandles={}", bar.numProxyHandles);
+        }
+        return ctx.out();
+    }
+};
+
+namespace wxUITests {
+
 enum class SizerType {
     Box,
     WrapBox,
@@ -169,6 +243,19 @@ enum class SizerType {
     FlexGrid,
 };
 struct TestParent;
+
+}
+
+// Specialize MenuItem type for TestParent (must be after forward declaration)
+namespace wxUI::customizations {
+template <>
+struct MenuItemTypeFor<wxUITests::TestParent> {
+    using type = wxUITests::TestMenuItem;
+};
+}
+
+namespace wxUITests {
+
 struct TestSizer {
     bool top { false };
     SizerType type { SizerType::Box };
@@ -201,6 +288,8 @@ struct TestParent {
     std::vector<std::string> bookPages {};
     std::list<TestParent> parents {};
     std::list<TestSizer> sizers {};
+    std::list<TestMenu> menus {}; // Storage for mock menus
+    std::list<TestMenuBar> menuBars {}; // Storage for mock menubars
 
     TestSizer* currentSizer {};
     TestParent* currentMenu {};
@@ -795,9 +884,102 @@ inline auto SizerCreate(wxUITests::TestParent* parent, SizerInfo const& info) ->
         info);
 }
 
-inline void MenuSetMenuBar(wxUITests::TestParent* parent, wxMenuBar* menuBar)
+// Menu customization overloads for TestParent - creates mock menus instead of real wx objects
+inline auto MenuCreate(wxUITests::TestParent& parent) -> wxUITests::TestMenu*
 {
-    // Represent the menu-bar as a child parent so tests can inspect it
+    parent.menus.emplace_back();
+    return &parent.menus.back();
+}
+
+inline auto MenuBarCreate(wxUITests::TestParent* parent) -> wxUITests::TestMenuBar*
+{
+    parent->menuBars.emplace_back();
+    return &parent->menuBars.back();
+}
+
+// Helper to get stock label/help for standard IDs
+namespace {
+    inline std::string getStockLabel(int id)
+    {
+        auto label = wxGetStockLabel(static_cast<wxWindowID>(id), wxSTOCK_NOFLAGS); // No mnemonic
+        return label.utf8_string();
+    }
+
+    inline std::string getStockHelp(int id)
+    {
+        // wxWidgets doesn't expose wxGetStockHelpString publicly, so we provide our own mapping
+        switch (id) {
+        case wxID_EXIT:
+            return "Quit this program";
+        case wxID_ABOUT:
+            return "Show about dialog";
+        default:
+            return "";
+        }
+    }
+}
+
+inline auto MenuAppend(wxUITests::TestMenu* menu, int id, wxString const& item, wxString const& help) -> wxUITests::TestMenuItem*
+{
+    // Mimic wxWidgets behavior: if item is empty and id is a standard ID, use default label/help
+    std::string label = item.utf8_string();
+    std::string helpText = help.utf8_string();
+    if (label.empty()) {
+        label = getStockLabel(id);
+    }
+    if (helpText.empty()) {
+        helpText = getStockHelp(id);
+    }
+    menu->items.push_back({ id, "normal", label, helpText });
+    return &menu->items.back();
+}
+
+inline auto MenuAppendCheckItem(wxUITests::TestMenu* menu, int id, wxString const& item, wxString const& help) -> wxUITests::TestMenuItem*
+{
+    // Mimic wxWidgets behavior: if item is empty and id is a standard ID, use default label/help
+    std::string label = item.utf8_string();
+    std::string helpText = help.utf8_string();
+    if (label.empty()) {
+        label = getStockLabel(id);
+    }
+    if (helpText.empty()) {
+        helpText = getStockHelp(id);
+    }
+    menu->items.push_back({ id, "check", label, helpText });
+    return &menu->items.back();
+}
+
+inline auto MenuAppendRadioItem(wxUITests::TestMenu* menu, int id, wxString const& item, wxString const& help) -> wxUITests::TestMenuItem*
+{
+    // Mimic wxWidgets behavior: if item is empty and id is a standard ID, use default label/help
+    std::string label = item.utf8_string();
+    std::string helpText = help.utf8_string();
+    if (label.empty()) {
+        label = getStockLabel(id);
+    }
+    if (helpText.empty()) {
+        helpText = getStockHelp(id);
+    }
+    menu->items.push_back({ id, "radio", label, helpText });
+    return &menu->items.back();
+}
+
+inline void MenuBarAppend(wxUITests::TestMenuBar* menuBar, wxUITests::TestMenu* menu, wxString const& name)
+{
+    menu->title = name.utf8_string();
+    menuBar->menus.push_back(*menu);
+}
+
+inline void MenuAppendSubMenu(wxUITests::TestMenu* parentMenu, wxUITests::TestMenu* subMenu, wxString const& name)
+{
+    subMenu->title = name.utf8_string();
+    // Represent submenu as a special menu item
+    parentMenu->items.push_back({ -1, std::format("submenu:{}", *subMenu), "", "" });
+}
+
+inline void MenuSetMenuBar(wxUITests::TestParent* parent, wxUITests::TestMenuBar* menuBar)
+{
+    // Just format it for inspection - it's already stored in parent->menuBars
     parent->menuDetails.push_back(std::format("MenuBar:{}", *menuBar));
 }
 
@@ -806,4 +988,41 @@ inline void MenuBindToFrame(wxUITests::TestParent& frame, int identity, std::var
     auto count = std::ranges::count_if(frame.log, [identity](auto const& e) { return e.starts_with(std::format("BindMenu:{}", identity)); });
     frame.log.push_back(std::format("BindMenu:{}:{}", identity, count + 1));
 }
+
+// Proxy binding customization points for menu items in tests
+// Note: In tests, we can't actually set the proxy because TestMenuItem* != wxMenuItem*
+// But calling the customization point is sufficient for test coverage
+template <typename Proxy>
+inline void MenuBindProxy(wxUITests::TestMenuItem* menu, Proxy&)
+{
+    menu->numProxyHandles += 1;
+}
+template <typename Proxy>
+inline void MenuBindProxy(wxUITests::TestMenu* menu, Proxy&)
+{
+    menu->numProxyHandles += 1;
+}
+template <typename Proxy>
+inline void MenuBindProxy(wxUITests::TestMenuBar* menu, Proxy&)
+{
+    menu->numProxyHandles += 1;
+}
+// template <typename ProxyType>
+// inline void MenuItemBindProxy(wxUITests::TestMenuItem*, ProxyType const&)
+// {
+//     // No-op in tests - the proxy type (Proxy<wxMenuItem>) doesn't match TestMenuItem*
+//     // This is acceptable because we're testing the code paths, not runtime behavior
+// }
+
+// template <typename ProxyType>
+// inline void MenuBindProxy(wxUITests::TestMenu*, ProxyType const&)
+// {
+//     // No-op in tests
+// }
+
+// template <typename ProxyType>
+// inline void MenuBarBindProxy(wxUITests::TestMenuBar*, ProxyType const&)
+// {
+//     // No-op in tests
+// }
 }

--- a/tests/wxUI_MenuTests.cpp
+++ b/tests/wxUI_MenuTests.cpp
@@ -85,13 +85,13 @@ auto RunMenuTest_id_func(Function function)
 template <typename MenuType>
 auto RunMenuTest_id_func1()
 {
-    RunMenuTest_id_func<MenuType>([]() {});
+    RunMenuTest_id_func<MenuType>([]() { });
 }
 
 template <typename MenuType>
 auto RunMenuTest_id_func2()
 {
-    RunMenuTest_id_func<MenuType>([](wxCommandEvent&) {});
+    RunMenuTest_id_func<MenuType>([](wxCommandEvent&) { });
 }
 
 template <typename MenuType>
@@ -126,13 +126,13 @@ auto RunMenuTest_id_name_func(Function function)
 template <typename MenuType>
 auto RunMenuTest_id_name_func1()
 {
-    RunMenuTest_id_name_func<MenuType>([]() {});
+    RunMenuTest_id_name_func<MenuType>([]() { });
 }
 
 template <typename MenuType>
 auto RunMenuTest_id_name_func2()
 {
-    RunMenuTest_id_name_func<MenuType>([](wxCommandEvent&) {});
+    RunMenuTest_id_name_func<MenuType>([](wxCommandEvent&) { });
 }
 
 template <typename MenuType>
@@ -168,13 +168,13 @@ auto RunMenuTest_id_name_help_func(Function function)
 template <typename MenuType>
 auto RunMenuTest_id_name_help_func1()
 {
-    RunMenuTest_id_name_help_func<MenuType>([]() {});
+    RunMenuTest_id_name_help_func<MenuType>([]() { });
 }
 
 template <typename MenuType>
 auto RunMenuTest_id_name_help_func2()
 {
-    RunMenuTest_id_name_help_func<MenuType>([](wxCommandEvent&) {});
+    RunMenuTest_id_name_help_func<MenuType>([](wxCommandEvent&) { });
 }
 
 template <typename MenuType, typename Function>
@@ -195,13 +195,13 @@ auto RunMenuTest_name_func(Function function)
 template <typename MenuType>
 auto RunMenuTest_name_func1()
 {
-    RunMenuTest_name_func<MenuType>([]() {});
+    RunMenuTest_name_func<MenuType>([]() { });
 }
 
 template <typename MenuType>
 auto RunMenuTest_name_func2()
 {
-    RunMenuTest_name_func<MenuType>([](wxCommandEvent&) {});
+    RunMenuTest_name_func<MenuType>([](wxCommandEvent&) { });
 }
 
 template <typename MenuType, typename Function>
@@ -222,13 +222,13 @@ auto RunMenuTest_name_help_func(Function function)
 template <typename MenuType>
 auto RunMenuTest_name_help_func1()
 {
-    RunMenuTest_name_help_func<MenuType>([]() {});
+    RunMenuTest_name_help_func<MenuType>([]() { });
 }
 
 template <typename MenuType>
 auto RunMenuTest_name_help_func2()
 {
-    RunMenuTest_name_help_func<MenuType>([](wxCommandEvent&) {});
+    RunMenuTest_name_help_func<MenuType>([](wxCommandEvent&) { });
 }
 
 template <typename MenuType>
@@ -265,13 +265,13 @@ auto RunMenuTest_id_name_tag_func(Function function)
 template <typename MenuType>
 auto RunMenuTest_id_name_tag_func1()
 {
-    RunMenuTest_id_name_tag_func<MenuType>([]() {});
+    RunMenuTest_id_name_tag_func<MenuType>([]() { });
 }
 
 template <typename MenuType>
 auto RunMenuTest_id_name_tag_func2()
 {
-    RunMenuTest_id_name_tag_func<MenuType>([](wxCommandEvent&) {});
+    RunMenuTest_id_name_tag_func<MenuType>([](wxCommandEvent&) { });
 }
 
 template <typename MenuType>
@@ -548,6 +548,87 @@ TEST_CASE("Menu")
     SECTION("menu.radioitem.menu.name_tag")
     {
         RunMenuTest_menu_name_tag<wxUI::RadioItem>();
+    }
+
+    SECTION("menu.item.proxy")
+    {
+        TestParent frame;
+        wxUI::MenuItemProxy proxy;
+        CHECK(proxy.control() == nullptr);
+
+        wxUI::MenuBar menu {
+            wxUI::Menu {
+                "Menu1",
+                wxUI::Item { wxID_EXIT }.withProxy(proxy) }
+        };
+        menu.fitTo(&frame);
+
+        CHECK(frame.dump() == std::vector { std::string { "menu:MenuBar:[[title:Menu1:[(menuItem:id=5006,kind=normal,label=\"Quit\",help=\"Quit this program\"):numProxyHandles=1,],]" } });
+    }
+
+    SECTION("menu.checkitem.proxy")
+    {
+        TestParent frame;
+        wxUI::MenuItemProxy proxy;
+        CHECK(proxy.control() == nullptr);
+
+        wxUI::MenuBar menu {
+            wxUI::Menu {
+                "Menu1",
+                wxUI::CheckItem { wxID_EXIT }.withProxy(proxy) }
+        };
+        menu.fitTo(&frame);
+
+        CHECK(frame.dump() == std::vector { std::string { "menu:MenuBar:[[title:Menu1:[(menuItem:id=5006,kind=check,label=\"Quit\",help=\"Quit this program\"):numProxyHandles=1,],]" } });
+    }
+
+    SECTION("menu.radioitem.proxy")
+    {
+        TestParent frame;
+        wxUI::MenuItemProxy proxy;
+        CHECK(proxy.control() == nullptr);
+
+        wxUI::MenuBar menu {
+            wxUI::Menu {
+                "Menu1",
+                wxUI::RadioItem { wxID_EXIT }.withProxy(proxy) }
+        };
+        menu.fitTo(&frame);
+
+        CHECK(frame.dump() == std::vector { std::string { "menu:MenuBar:[[title:Menu1:[(menuItem:id=5006,kind=radio,label=\"Quit\",help=\"Quit this program\"):numProxyHandles=1,],]" } });
+    }
+
+    SECTION("menu.proxy")
+    {
+        TestParent frame;
+        wxUI::MenuProxy proxy;
+        CHECK(proxy.control() == nullptr);
+
+        wxUI::MenuBar menuBar {
+            wxUI::Menu {
+                "Menu1",
+                wxUI::Item { wxID_EXIT } }
+                .withProxy(proxy)
+        };
+        menuBar.fitTo(&frame);
+
+        CHECK(frame.dump() == std::vector { std::string { "menu:MenuBar:[[title:Menu1:[(menuItem:id=5006,kind=normal,label=\"Quit\",help=\"Quit this program\"),]:numProxyHandles=1,]" } });
+    }
+
+    SECTION("menubar.proxy")
+    {
+        TestParent frame;
+        wxUI::MenuBarProxy proxy;
+        CHECK(proxy.control() == nullptr);
+
+        wxUI::MenuBar {
+            wxUI::Menu {
+                "Menu1",
+                wxUI::Item { wxID_EXIT } }
+        }.withProxy(proxy)
+            .fitTo(&frame);
+
+        CHECK(frame.dump() == std::vector { std::string { "menu:MenuBar:[[title:Menu1:[(menuItem:id=5006,kind=normal,label=\"Quit\",help=\"Quit this program\"),],]:numProxyHandles=1" } });
     }
 }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, readability-function-cognitive-complexity)


### PR DESCRIPTION
Add Menu customization points to enable mock objects in tests

- Added MenuCreate, MenuBarCreate, MenuAppend, MenuAppendCheckItem, MenuAppendRadioItem, MenuBarAppend, MenuAppendSubMenu to Customizations.hpp
- Updated Menu.hpp to use customization points instead of directly creating wxMenu/wxMenuBar
- Added tag dispatch (ToMenuBarTag, ToMenuTag) to disambiguate Menu::createAndAdd overloads
- Templated Menu/MenuBar proxy handling to accept both wxWidget and test mock types
- Added TestMenu, TestMenuBar, TestMenuItem mock structures in TestCustomizations.hpp
- Implemented stock label/help text handling for standard IDs in test mocks
- All 39 test cases pass (2169 assertions) including Menu tests
- Menu tests no longer require real wxMenu/wxMenuBar objects, eliminating Windows ID management assertion failures