### PR TITLE
Issue #361: Fixed scrollable windows

### DIFF
--- a/include/wxUI/detail/HelperMacros.hpp
+++ b/include/wxUI/detail/HelperMacros.hpp
@@ -148,10 +148,16 @@ SOFTWARE.
 #endif
 
 #if !defined(WXUI_FITTO_DETAILS)
-#define WXUI_FITTO_DETAILS()              \
-    template <typename Parent>            \
-    auto fitTo(Parent* parent) -> Parent* \
-    {                                     \
-        return details_.fitTo(parent);    \
+#define WXUI_FITTO_DETAILS()                  \
+    template <typename Parent>                \
+    auto fitTo(Parent* parent) -> Parent*     \
+    {                                         \
+        return details_.fitTo(parent);        \
+    }                                         \
+                                              \
+    template <typename Parent>                \
+    auto fitInside(Parent* parent) -> Parent* \
+    {                                         \
+        return details_.fitInside(parent);    \
     }
 #endif

--- a/include/wxUI/detail/LayoutDetails.hpp
+++ b/include/wxUI/detail/LayoutDetails.hpp
@@ -134,6 +134,15 @@ struct Sizer {
         return parent;
     }
 
+    template <typename CreatorFunction, typename Parent>
+    auto fitInside(CreatorFunction creator, Parent* parent) -> Parent*
+    {
+        auto* sizer = createAndAddWidgets(creator, parent, flags_.value_or(wxSizerFlags {}));
+        parent->SetSizer(sizer);
+        sizer->FitInside(parent);
+        return parent;
+    }
+
 private:
     template <typename CreatorFunction, typename Parent>
     auto createAndAddWidgets(CreatorFunction creator, Parent* parent, wxSizerFlags const& flags)
@@ -238,11 +247,17 @@ struct BoxSizer {
     {
         if (std::get<0>(scrollRate_).has_value() || std::get<1>(scrollRate_).has_value()) {
             using ::wxUI::customizations::ScrolledWindowCreate;
+            using ::wxUI::customizations::BoxSizerInfo;
             auto scroller = ScrolledWindowCreate(parent);
-            details_.fitTo(this->template createImpl<std::remove_pointer_t<decltype(scroller)>>(), scroller);
+            details_.fitInside(this->template createImpl<std::remove_pointer_t<decltype(scroller)>>(), scroller);
             auto xScrollRate = std::get<0>(scrollRate_).value_or(1);
             auto yScrollRate = std::get<1>(scrollRate_).value_or(xScrollRate);
             scroller->SetScrollRate(xScrollRate, yScrollRate);
+            scroller->SetMinSize(wxSize { 0, 0 });
+            auto sizer = SizerCreate(parent, BoxSizerInfo { std::nullopt, wxVERTICAL });
+            sizer->Add(scroller, wxSizerFlags { 1 }.Expand());
+            parent->SetSizer(sizer);
+            sizer->SetSizeHints(parent);
             return parent;
         }
         return details_.fitTo(this->template createImpl<Parent>(), parent);

--- a/include/wxUI/detail/LayoutDetails.hpp
+++ b/include/wxUI/detail/LayoutDetails.hpp
@@ -246,18 +246,22 @@ struct BoxSizer {
     auto fitTo(Parent* parent) -> Parent*
     {
         if (std::get<0>(scrollRate_).has_value() || std::get<1>(scrollRate_).has_value()) {
-            using ::wxUI::customizations::ScrolledWindowCreate;
             using ::wxUI::customizations::BoxSizerInfo;
+            using ::wxUI::customizations::ScrolledWindowCreate;
+            using ::wxUI::customizations::SizerCreate;
+
             auto scroller = ScrolledWindowCreate(parent);
             details_.fitInside(this->template createImpl<std::remove_pointer_t<decltype(scroller)>>(), scroller);
             auto xScrollRate = std::get<0>(scrollRate_).value_or(1);
             auto yScrollRate = std::get<1>(scrollRate_).value_or(xScrollRate);
             scroller->SetScrollRate(xScrollRate, yScrollRate);
             scroller->SetMinSize(wxSize { 0, 0 });
+
             auto sizer = SizerCreate(parent, BoxSizerInfo { std::nullopt, wxVERTICAL });
             sizer->Add(scroller, wxSizerFlags { 1 }.Expand());
             parent->SetSizer(sizer);
             sizer->SetSizeHints(parent);
+
             return parent;
         }
         return details_.fitTo(this->template createImpl<Parent>(), parent);

--- a/tests/TestCustomizations.hpp
+++ b/tests/TestCustomizations.hpp
@@ -272,6 +272,7 @@ struct TestSizer {
     wxOrientation orientation {};
     std::optional<int> cols {};
 
+    void FitInside(TestParent*);
     void SetSizeHints(TestParent*);
     void Add(TestParent*, wxSizerFlags const& flags);
     void Add(TestSizer*, wxSizerFlags const& flags);
@@ -524,6 +525,11 @@ inline auto TestParent::dump() const -> std::vector<std::string>
         result.push_back(std::format("scroller:{}", scroller));
     }
     return result;
+}
+
+inline void TestSizer::FitInside(TestParent* controller)
+{
+    log.push_back(std::format("FitInside:{}", *controller));
 }
 
 inline void TestSizer::SetSizeHints(TestParent* controller)

--- a/tests/TestCustomizations.hpp
+++ b/tests/TestCustomizations.hpp
@@ -417,7 +417,7 @@ struct std::formatter<wxUITests::TestParent, char> {
             std::format_to(ctx.out(), ", majorDim={}", *c.majorDim);
         }
         if (c.minSize.has_value()) {
-            std::format_to(ctx.out(), ", minSize={},{}", c.minSize.GetWidth(), c.minSize.GetHeight());
+            std::format_to(ctx.out(), ", minSize={},{}", c.minSize->GetWidth(), c.minSize->GetHeight());
         }
         return std::format_to(ctx.out(), "]");
     }

--- a/tests/TestCustomizations.hpp
+++ b/tests/TestCustomizations.hpp
@@ -295,6 +295,7 @@ struct TestParent {
     std::optional<wxColour> color {};
     std::optional<std::pair<int, int>> range {};
     std::optional<int> majorDim {};
+    std::optional<wxSize> minSize {};
 
     std::vector<std::string> log {};
     std::vector<std::string> menuDetails {};
@@ -340,6 +341,10 @@ struct TestParent {
     void Set3StateValue(wxCheckBoxState value)
     {
         log.push_back(std::format("Set3StateValue:{}", value == wxCHK_UNCHECKED ? "unchecked" : (value == wxCHK_CHECKED ? "checked" : "undetermined")));
+    }
+    void SetMinSize(wxSize const& value)
+    {
+        log.push_back(std::format("SetMinSize:{},{}", value.GetWidth(), value.GetHeight()));
     }
     void Wrap(bool value)
     {
@@ -410,6 +415,9 @@ struct std::formatter<wxUITests::TestParent, char> {
         }
         if (c.majorDim.has_value()) {
             std::format_to(ctx.out(), ", majorDim={}", *c.majorDim);
+        }
+        if (c.minSize.has_value()) {
+            std::format_to(ctx.out(), ", minSize={},{}", c.minSize.GetWidth(), c.minSize.GetHeight());
         }
         return std::format_to(ctx.out(), "]");
     }

--- a/tests/wxUI_LayoutTests.cpp
+++ b/tests/wxUI_LayoutTests.cpp
@@ -749,6 +749,7 @@ TEST_CASE("Size")
                   "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
                   "SetScrollRate:2,3",
                   "SetMinSize:0,0",
+                  "Create:Sizer[orientation=wxVERTICAL]",
                   "topsizer:Sizer[orientation=wxVERTICAL]",
                   "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
                   "SetEnabled:true",

--- a/tests/wxUI_LayoutTests.cpp
+++ b/tests/wxUI_LayoutTests.cpp
@@ -757,6 +757,7 @@ TEST_CASE("Size")
                   "Add:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]:flags:(0,0x0,0)",
                   "FitInside:[id=0, pos=(0,0), size=(0,0), style=0]",
                   "sizer:Sizer[orientation=wxVERTICAL]",
+                  "Add:[id=0, pos=(0,0), size=(0,0), style=0]:flags:(1,0x2000,0)",
                   "SetSizeHints:[id=0, pos=(0,0), size=(0,0), style=0]",
                   "scroller:[id=0, pos=(0,0), size=(0,0), style=0]",
               });

--- a/tests/wxUI_LayoutTests.cpp
+++ b/tests/wxUI_LayoutTests.cpp
@@ -754,6 +754,8 @@ TEST_CASE("Size")
                   "SetEnabled:true",
                   "sizer:Sizer[orientation=wxVERTICAL]",
                   "Add:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]:flags:(0,0x0,0)",
+                  "FitInside:[id=0, pos=(0,0), size=(0,0), style=0]",
+                  "sizer:Sizer[orientation=wxVERTICAL]",
                   "SetSizeHints:[id=0, pos=(0,0), size=(0,0), style=0]",
                   "scroller:[id=0, pos=(0,0), size=(0,0), style=0]",
               });

--- a/tests/wxUI_LayoutTests.cpp
+++ b/tests/wxUI_LayoutTests.cpp
@@ -748,6 +748,7 @@ TEST_CASE("Size")
                   "Create:Sizer[orientation=wxVERTICAL]",
                   "Create:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
                   "SetScrollRate:2,3",
+                  "SetMinSize:0,0",
                   "topsizer:Sizer[orientation=wxVERTICAL]",
                   "controller:wxButton[id=-1, pos=(-1,-1), size=(-1,-1), style=0, text=\"Hello\"]",
                   "SetEnabled:true",


### PR DESCRIPTION
The current implementation of scrollbars did not set the virtual size of the window and allow auto-sizing of the parent window containing the scrollbars. This PR fixes this issue.